### PR TITLE
chore(katechat-ui): drop unused react-redux peer dependency

### DIFF
--- a/packages/katechat-ui/README.md
+++ b/packages/katechat-ui/README.md
@@ -40,7 +40,6 @@ This package requires the following peer dependencies:
   "@tabler/icons-react": "^3.1.0",
   "react": "19.1.0",
   "react-dom": "19.1.0",
-  "react-redux": "^9.2.0",
   "react-router-dom": "^6.23.1"
 }
 ```

--- a/packages/katechat-ui/esbuild.js
+++ b/packages/katechat-ui/esbuild.js
@@ -19,7 +19,6 @@ const buildConfig = {
     "react",
     "react-dom",
     "react-router-dom",
-    "react-redux",
     "react-i18next",
     "i18next",
     "i18next-browser-languagedetector",

--- a/packages/katechat-ui/package.json
+++ b/packages/katechat-ui/package.json
@@ -69,7 +69,6 @@
     "@tabler/icons-react": "^3.1.0",
     "react": "19.1.0",
     "react-dom": "19.1.0",
-    "react-redux": "^9.2.0",
     "react-router-dom": "^6.23.1",
     "react-i18next": "^16.5.4"
   },
@@ -105,7 +104,6 @@
     "prettier": "^3.2.5",
     "react": "19.1.0",
     "react-dom": "19.1.0",
-    "react-redux": "^9.2.0",
     "react-router-dom": "^6.23.1",
     "sass": "^1.71.1",
     "ts-jest": "^29.4.5",


### PR DESCRIPTION
## Summary
- Removes `react-redux` from `peerDependencies` and `devDependencies` of `@katechat/ui`. The library has no Redux usage anywhere in `packages/katechat-ui/src/` — `grep -rln 'react-redux\|@reduxjs/toolkit\|from .redux' packages/katechat-ui/src/` returns nothing.
- Also drops the matching line from the package's README peer-deps snippet.

## Why
Consumers integrating `@katechat/ui` are forced to wrap their tree in `<Provider store={...}>` with a dummy `configureStore({ reducer: {} })`, which fires the misleading **"Store does not have a valid reducer"** warning at startup (because `combineReducers` requires at least one reducer). With the peer dep removed, consumers can drop the Provider entirely and the warning goes away.

```diff
- import { Provider as ReduxProvider } from "react-redux";
- import { configureStore } from "@reduxjs/toolkit";
- const store = configureStore({ reducer: {} });   // ⚠ Store does not have a valid reducer
- <ReduxProvider store={store}><App /></ReduxProvider>
+ <App />
```

## Test plan
- [ ] `npm install` in a downstream consumer of `@katechat/ui` no longer warns about a missing `react-redux` peer.
- [ ] Removing `<Provider>` and the `configureStore` boilerplate from the consumer leaves `ChatMessagesContainer` / `ChatInput` rendering identically.
- [ ] The startup console no longer shows "Store does not have a valid reducer."
- [ ] CI builds (`npm run build` in `packages/katechat-ui`) still succeed — there's no code change here, only manifest cleanup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)