### PR TITLE
Fix CI: deploys silently skipped when document-processor job is skipped

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -152,7 +152,12 @@ jobs:
     name: Build and Push Images
     runs-on: ubuntu-latest
     needs: [test, lint, changes, rust-document-processor]
-    if: needs.changes.outputs.api == 'true' || needs.changes.outputs.client == 'true' || needs.changes.outputs.document_processor == 'true'
+    # rust-document-processor is skipped when document-processor/** is
+    # untouched; without a status-check function a skipped need would skip
+    # this job (and deploy-staging/security-scan behind it) too
+    if: >-
+      !failure() && !cancelled() &&
+      (needs.changes.outputs.api == 'true' || needs.changes.outputs.client == 'true' || needs.changes.outputs.document_processor == 'true')
 
     outputs:
       app-image: ${{ steps.build-app.outputs.image }}


### PR DESCRIPTION
## Summary

Since the Rust migration (#131) added `rust-document-processor` to the `build` job's `needs`, every master push that does not touch `document-processor/**` skips that job — and GitHub Actions skips a dependent job when any of its needs was skipped, unless the job's `if` contains a status-check function. As a result **Build and Push Images**, **Deploy to Staging**, and **Security Scan** have been silently skipped on such pushes (including the #137 and #139 merges) while the workflow stayed green.

The fix prefixes the `build` job's condition with `!failure() && !cancelled()`, which tolerates the skipped Rust job but still blocks the build when tests or lint actually fail. `deploy-staging` and `security-scan` need no change — their plain conditions work again once `build` runs.

## Testing

- YAML validated; condition evaluates as before for the path-filter part.
- Behavior per GitHub Actions docs: a job with skipped needs runs only when its `if` includes a status-check function such as `!failure() && !cancelled()`; a failed need still yields `failure() == true` and skips the job.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018GfDqRAeCbu2hgFja8Utu9

---
_Generated by [Claude Code](https://claude.ai/code/session_018GfDqRAeCbu2hgFja8Utu9)_