### PR TITLE
Add force_redeploy flag to CI/CD manual runs

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -8,6 +8,11 @@ on:
     branches:
       - master
   workflow_dispatch:
+    inputs:
+      force_redeploy:
+        description: 'Build and deploy the app even if no relevant changes are detected'
+        type: boolean
+        default: false
 
 permissions:
   id-token: write  # Required for OIDC
@@ -75,9 +80,13 @@ jobs:
   changes:
     name: Detect Changes
     runs-on: ubuntu-latest
+    # force_redeploy (manual workflow_dispatch) marks api/client as changed so
+    # the app image is rebuilt and redeployed even without code changes;
+    # packages/document_processor keep real detection (no forced npm publish
+    # or document-processor rebuild)
     outputs:
-      api: ${{ steps.changes.outputs.api }}
-      client: ${{ steps.changes.outputs.client }}
+      api: ${{ steps.changes.outputs.api == 'true' || inputs.force_redeploy == true }}
+      client: ${{ steps.changes.outputs.client == 'true' || inputs.force_redeploy == true }}
       packages: ${{ steps.changes.outputs.packages }}
       document_processor: ${{ steps.changes.outputs.document_processor }}
       docs: ${{ steps.changes.outputs.docs }}


### PR DESCRIPTION
## Summary

Follow-up to #141: that fix unblocked the deploy chain, but a merge that touches no `api`/`client` paths (workflow-only or examples-only, like #140/#141 themselves) still legitimately skips build and deploy — there is nothing "changed" for the paths filter to see, so a stale image stays on staging.

This adds a `force_redeploy` boolean input to `workflow_dispatch`. When checked, the Detect Changes job reports `api`/`client` as changed, so the app image is rebuilt and staging is redeployed even without relevant file changes. `packages` (NPM publish) and `document_processor` keep real change detection — a forced run does not bump/publish `@katechat/ui` or rebuild the document processor.

**Usage:** Actions → CI/CD Pipeline → Run workflow → check "Build and deploy the app even if no relevant changes are detected".

On push/PR events the input is absent (`inputs.force_redeploy` is null), so behavior is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018GfDqRAeCbu2hgFja8Utu9

---
_Generated by [Claude Code](https://claude.ai/code/session_018GfDqRAeCbu2hgFja8Utu9)_