### PR TITLE
Fix load-more cascade when scrolling a long chat to the top

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7804,9 +7804,6 @@
       "cpu": [
         "arm"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -7826,9 +7823,6 @@
       "integrity": "sha512-Ve3gUCG57nuUUSyjBq/MAM0CzArtuIOxsBdQ+ftz6ho8n7s1i9E1Nmk/xmP323r2YL0SONs1EuwqBp2u1k5fxg==",
       "cpu": [
         "arm"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -7850,9 +7844,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -7872,9 +7863,6 @@
       "integrity": "sha512-qb6naMDGlbCwdhLj6hgoVKJl2odL34z2sqkC7Z6kzir8b5W65WYDpLB6R06KabvZdgoHI/zxke4b3zR0wAbDTA==",
       "cpu": [
         "arm64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -7896,9 +7884,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -7918,9 +7903,6 @@
       "integrity": "sha512-1JRFeC+h7RdXwldHzTsmdtYR/Ku8SylLgTU/reMuqdVD7CtLwf0VR1FqeprZ0eHQkO0vqsbvFLXUmYm/uNKJBg==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -8834,6 +8816,26 @@
       "integrity": "sha512-z9ZBWEG+8pIB5V1zYzlRPXx0oRJ5H7coPnMQK8EZOw03UTPI9Umn6viL36f5w+CuqkKsnCM50RVStpjZmR0Bng==",
       "license": "MIT"
     },
+    "node_modules/@testing-library/dom": {
+      "version": "10.4.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-10.4.1.tgz",
+      "integrity": "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.10.4",
+        "@babel/runtime": "^7.12.5",
+        "@types/aria-query": "^5.0.1",
+        "aria-query": "5.3.0",
+        "dom-accessibility-api": "^0.5.9",
+        "lz-string": "^1.5.0",
+        "picocolors": "1.1.1",
+        "pretty-format": "^27.0.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/@testing-library/jest-dom": {
       "version": "6.6.3",
       "dev": true,
@@ -8931,6 +8933,13 @@
     },
     "node_modules/@tsconfig/node16": {
       "version": "1.0.4",
+      "license": "MIT"
+    },
+    "node_modules/@types/aria-query": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
+      "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/babel__core": {
@@ -11202,6 +11211,13 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/dom-accessibility-api": {
+      "version": "0.5.16",
+      "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
+      "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/dom-helpers": {
       "version": "5.2.1",
@@ -14769,6 +14785,16 @@
         "url": "https://github.com/sponsors/wellwelwel"
       }
     },
+    "node_modules/lz-string": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/lz-string/-/lz-string-1.5.0.tgz",
+      "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "lz-string": "bin/bin.js"
+      }
+    },
     "node_modules/make-dir": {
       "version": "4.0.0",
       "dev": true,
@@ -16356,6 +16382,51 @@
       "funding": {
         "url": "https://github.com/prettier/prettier?sponsor=1"
       }
+    },
+    "node_modules/pretty-format": {
+      "version": "27.5.1",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.5.1.tgz",
+      "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1",
+        "ansi-styles": "^5.0.0",
+        "react-is": "^17.0.1"
+      },
+      "engines": {
+        "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
+      }
+    },
+    "node_modules/pretty-format/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/pretty-format/node_modules/ansi-styles": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/pretty-format/node_modules/react-is": {
+      "version": "17.0.2",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
+      "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/process": {
       "version": "0.11.10",
@@ -19667,6 +19738,7 @@
         "@mantine/hooks": "8.3.15",
         "@mantine/modals": "8.3.15",
         "@mantine/notifications": "8.3.15",
+        "@testing-library/dom": "^10.4.1",
         "@testing-library/jest-dom": "^6.6.3",
         "@testing-library/react": "^16.3.0",
         "@types/jest": "^29.5.12",

--- a/packages/katechat-ui/package.json
+++ b/packages/katechat-ui/package.json
@@ -57,9 +57,6 @@
     "marked-katex-extension": "^5.1.5"
   },
   "peerDependencies": {
-    "i18next": "^25.6.2",
-    "i18next-browser-languagedetector": "^7.0.1",
-    "idb": "^8.0.1",
     "@mantine/core": "8.3.15",
     "@mantine/dates": "8.3.15",
     "@mantine/form": "8.3.15",
@@ -67,10 +64,13 @@
     "@mantine/modals": "8.3.15",
     "@mantine/notifications": "8.3.15",
     "@tabler/icons-react": "^3.1.0",
+    "i18next": "^25.6.2",
+    "i18next-browser-languagedetector": "^7.0.1",
+    "idb": "^8.0.1",
     "react": "19.1.0",
     "react-dom": "19.1.0",
-    "react-router-dom": "^6.30.4",
-    "react-i18next": "^16.5.4"
+    "react-i18next": "^16.5.4",
+    "react-router-dom": "^6.30.4"
   },
   "devDependencies": {
     "@babel/preset-env": "^7.24.5",
@@ -82,6 +82,7 @@
     "@mantine/hooks": "8.3.15",
     "@mantine/modals": "8.3.15",
     "@mantine/notifications": "8.3.15",
+    "@testing-library/dom": "^10.4.1",
     "@testing-library/jest-dom": "^6.6.3",
     "@testing-library/react": "^16.3.0",
     "@types/jest": "^29.5.12",

--- a/packages/katechat-ui/src/components/chat/ChatMessagesContainer.tsx
+++ b/packages/katechat-ui/src/components/chat/ChatMessagesContainer.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useEffect, useImperativeHandle, useRef, useState } from "react";
+import React, { useCallback, useEffect, useImperativeHandle, useLayoutEffect, useRef, useState } from "react";
 import { Group, Loader } from "@mantine/core";
 import { IconCircleChevronDown } from "@tabler/icons-react";
 import { Message, Model, PluginProps, CodePlugin } from "@/core";
@@ -156,11 +156,41 @@ export const ChatMessagesContainer = React.forwardRef<ChatMessagesContainerRef, 
       }
     }, [loadCompleted, autoScroll]);
 
-    const firstMessageRef = useIntersectionObserver<HTMLDivElement>(
-      () => loadMoreMessages?.(),
-      [loadMoreMessages],
-      200
-    );
+    // Snapshot of the scroller taken right before older messages are
+    // requested, used to keep the viewport anchored after they are prepended
+    const prependSnapshot = useRef<{ scrollHeight: number; scrollTop: number } | null>(null);
+    const prevFirstMessageId = useRef<string | undefined>(undefined);
+
+    const handleLoadMore = useCallback(() => {
+      const el = messagesContainerRef.current;
+      if (el) {
+        prependSnapshot.current = { scrollHeight: el.scrollHeight, scrollTop: el.scrollTop };
+      }
+      loadMoreMessages?.();
+    }, [loadMoreMessages]);
+
+    // When an older page is prepended the browser keeps scrollTop as-is
+    // (scroll anchoring is off at scrollTop=0), leaving the load-more sentinel
+    // in view — restore the position so the previously visible message stays
+    // put and the next page loads only when the user scrolls up again
+    useLayoutEffect(() => {
+      const el = messagesContainerRef.current;
+      const snapshot = prependSnapshot.current;
+      const firstMessageId = messages?.length ? messages[0].id : undefined;
+
+      if (el && snapshot && firstMessageId && prevFirstMessageId.current !== firstMessageId) {
+        const delta = el.scrollHeight - snapshot.scrollHeight;
+        if (delta > 0) {
+          isProgrammaticScroll.current = true;
+          el.scrollTop = snapshot.scrollTop + delta;
+        }
+      }
+
+      prependSnapshot.current = null;
+      prevFirstMessageId.current = firstMessageId;
+    }, [messages]);
+
+    const firstMessageRef = useIntersectionObserver<HTMLDivElement>(handleLoadMore, [handleLoadMore], 200);
 
     // #endregion
 

--- a/packages/katechat-ui/src/hooks/__tests__/useIntersectionObserver.test.tsx
+++ b/packages/katechat-ui/src/hooks/__tests__/useIntersectionObserver.test.tsx
@@ -1,0 +1,105 @@
+import { renderHook, act } from "@testing-library/react";
+import { useIntersectionObserver } from "../useIntersectionObserver";
+
+// jsdom has no IntersectionObserver; emulate the browser contract the hook
+// relies on — a new observer immediately reports the current intersection
+// state of an observed target, then reports transitions.
+let mockVisible = false;
+
+class MockIntersectionObserver {
+  static instances: MockIntersectionObserver[] = [];
+  private target: Element | null = null;
+
+  constructor(private cb: IntersectionObserverCallback) {
+    MockIntersectionObserver.instances.push(this);
+  }
+
+  observe(el: Element) {
+    this.target = el;
+    this.emit(mockVisible);
+  }
+
+  disconnect() {
+    this.target = null;
+  }
+
+  emit(isIntersecting: boolean) {
+    if (!this.target) return;
+    this.cb([{ isIntersecting } as IntersectionObserverEntry], this as unknown as IntersectionObserver);
+  }
+
+  static get last(): MockIntersectionObserver {
+    return MockIntersectionObserver.instances[MockIntersectionObserver.instances.length - 1];
+  }
+}
+
+beforeEach(() => {
+  jest.useFakeTimers();
+  mockVisible = false;
+  MockIntersectionObserver.instances = [];
+  (globalThis as Record<string, unknown>).IntersectionObserver = MockIntersectionObserver;
+});
+
+afterEach(() => {
+  jest.useRealTimers();
+});
+
+const setup = (callback: () => void) => {
+  const rendered = renderHook(({ cb }) => useIntersectionObserver<HTMLDivElement>(cb, [cb], 100), {
+    initialProps: { cb: callback },
+  });
+  rendered.result.current.current = document.createElement("div");
+  // deps identity changes on rerender, so the observer is rebuilt and picks up
+  // the ref target — same as in real consumers re-rendering on state changes
+  rendered.rerender({ cb: callback });
+  act(() => {
+    jest.advanceTimersByTime(100);
+  });
+  return rendered;
+};
+
+describe("useIntersectionObserver", () => {
+  it("fires when the target enters the viewport", () => {
+    const callback = jest.fn();
+    setup(callback);
+
+    expect(callback).not.toHaveBeenCalled();
+
+    act(() => MockIntersectionObserver.last.emit(true));
+    expect(callback).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not re-fire when the observer is re-created while the target stays visible", () => {
+    mockVisible = true;
+    const callback = jest.fn();
+    const { rerender } = setup(callback);
+
+    // initial report of the visible target
+    expect(callback).toHaveBeenCalledTimes(1);
+
+    // consumer re-renders (e.g. a messages page was prepended): the observer
+    // is torn down and re-created, immediately reporting the still-visible
+    // target — this must NOT trigger another load
+    mockVisible = true;
+    rerender({ cb: callback });
+    act(() => {
+      jest.advanceTimersByTime(100);
+    });
+
+    expect(callback).toHaveBeenCalledTimes(1);
+  });
+
+  it("fires again after the target leaves and re-enters the viewport", () => {
+    mockVisible = true;
+    const callback = jest.fn();
+    setup(callback);
+    expect(callback).toHaveBeenCalledTimes(1);
+
+    act(() => {
+      MockIntersectionObserver.last.emit(false);
+      MockIntersectionObserver.last.emit(true);
+    });
+
+    expect(callback).toHaveBeenCalledTimes(2);
+  });
+});

--- a/packages/katechat-ui/src/hooks/useIntersectionObserver.ts
+++ b/packages/katechat-ui/src/hooks/useIntersectionObserver.ts
@@ -3,12 +3,22 @@ import { DependencyList, useEffect, useRef } from "react";
 export function useIntersectionObserver<T extends HTMLElement>(callback: () => void, deps: DependencyList, delay = 0) {
   const observer = useRef<IntersectionObserver | null>(null);
   const ref = useRef<T>(null);
+  // Persisted across observer re-creations: the observer is torn down and
+  // rebuilt whenever deps/callback change (in practice on every render of the
+  // consumer), and a freshly created IntersectionObserver immediately reports
+  // the current state. Without tracking the previous state the callback would
+  // re-fire in a loop while the target stays visible — e.g. loading every
+  // messages page in a row after a single scroll to the top.
+  const wasIntersecting = useRef<boolean>(false);
 
   useEffect(() => {
     observer.current?.disconnect();
     const timeoutId = setTimeout(() => {
       observer.current = new IntersectionObserver(entries => {
-        if (entries[0].isIntersecting) callback();
+        const isIntersecting = entries[0].isIntersecting;
+        // fire only on the "entered the viewport" transition
+        if (isIntersecting && !wasIntersecting.current) callback();
+        wasIntersecting.current = isIntersecting;
       });
 
       if (ref.current) observer.current.observe(ref.current);


### PR DESCRIPTION
## Summary

Scrolling a long chat (>2 pages) to the top loaded **every** available page instead of one. Two combined causes:

1. `useIntersectionObserver` tears down and re-creates the observer on every consumer render (deps/callback identity change), and a freshly created `IntersectionObserver` immediately reports the current state — so while the top sentinel stayed visible, each prepended page triggered a render, which re-created the observer, which fired `loadMoreMessages` again.
2. At `scrollTop = 0` the browser's scroll anchoring is inactive, so after older messages were prepended the viewport stayed at the very top and the sentinel never left the visible area.

## Changes

- **`useIntersectionObserver`**: the callback now fires only on the "entered the viewport" transition; the previous intersection state is kept in a ref that survives observer re-creations.
- **`ChatMessagesContainer`**: snapshots `scrollHeight`/`scrollTop` right before requesting older messages and restores the position after the prepend (guarded by a first-message-id change), so the previously visible message stays put and the next page loads only when the user scrolls up again.
- Added `@testing-library/dom` dev dependency (peer of `@testing-library/react` v16, was missing) and unit tests for the hook covering the re-creation and re-enter scenarios.

## Testing

- `@katechat/ui`: 69 tests pass (3 new for the hook), typecheck and prettier clean
- client: 29 tests pass (dev alias uses the package src)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018GfDqRAeCbu2hgFja8Utu9

---
_Generated by [Claude Code](https://claude.ai/code/session_018GfDqRAeCbu2hgFja8Utu9)_