### PR TITLE
Fix Deploy to Staging skip caused by transitive skipped dependency

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -279,7 +279,13 @@ jobs:
     name: Deploy to Staging
     runs-on: ubuntu-latest
     needs: [build, changes]
-    if: github.ref == 'refs/heads/master' && (needs.changes.outputs.api == 'true' || needs.changes.outputs.client == 'true' || needs.changes.outputs.document_processor == 'true')
+    # the implicit success() looks at the TRANSITIVE needs chain, so a skipped
+    # rust-document-processor (an ancestor via build) would skip this job even
+    # when build itself succeeded — require the direct dependency explicitly
+    if: >-
+      !failure() && !cancelled() && needs.build.result == 'success' &&
+      github.ref == 'refs/heads/master' &&
+      (needs.changes.outputs.api == 'true' || needs.changes.outputs.client == 'true' || needs.changes.outputs.document_processor == 'true')
 
     steps:
     - name: Checkout code
@@ -405,7 +411,11 @@ jobs:
     name: Security Scan
     runs-on: ubuntu-latest
     needs: [build, changes]
-    if: github.ref == 'refs/heads/master' && (needs.changes.outputs.api == 'true' || needs.changes.outputs.client == 'true' || needs.changes.outputs.document_processor == 'true')
+    # same transitive-skip guard as deploy-staging
+    if: >-
+      !failure() && !cancelled() && needs.build.result == 'success' &&
+      github.ref == 'refs/heads/master' &&
+      (needs.changes.outputs.api == 'true' || needs.changes.outputs.client == 'true' || needs.changes.outputs.document_processor == 'true')
     continue-on-error: true
     
     steps:


### PR DESCRIPTION
## Summary

Follow-up to #141. In run [29007919485](https://github.com/artiz/kate-chat/actions/runs/29007919485) (merge of #143) **Build and Push Images succeeded** and pushed the app image, but **Deploy to Staging** and **Security Scan** were still skipped.

Cause: the implicit `success()` in a job-level `if` evaluates the **transitive** needs chain, not just direct dependencies. `deploy-staging` needs `build`, `build` needs `rust-document-processor`, and the latter was skipped (no `document-processor/**` changes) — so `deploy-staging` and `security-scan` were skipped despite both direct needs succeeding. #141 added the status-check guard only to `build`.

## Changes

Both `deploy-staging` and `security-scan` now use:

```yaml
if: >-
  !failure() && !cancelled() && needs.build.result == 'success' &&
  github.ref == 'refs/heads/master' &&
  (needs.changes.outputs.api == 'true' || needs.changes.outputs.client == 'true' || needs.changes.outputs.document_processor == 'true')
```

The explicit `needs.build.result == 'success'` keeps the original guarantee: no deploy unless an image was actually built and pushed in this run (a failed or skipped build still blocks it).

## Testing

- YAML validated; conditions verified for the three scenarios: rust skipped + build success → deploy runs; build failed → deploy skipped; docs-only push (build skipped) → deploy skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018GfDqRAeCbu2hgFja8Utu9

---
_Generated by [Claude Code](https://claude.ai/code/session_018GfDqRAeCbu2hgFja8Utu9)_