### PR TITLE
Test custom Embedding models with an embeddings request

### DIFF
--- a/api/src/resolvers/model.resolver.ts
+++ b/api/src/resolvers/model.resolver.ts
@@ -37,6 +37,12 @@ export class ModelResolver extends BaseResolver {
     this.aiService = new AIService();
   }
 
+  private static formatEmbeddingPreview(embedding: number[]): string {
+    const previewLength = 10;
+    const preview = embedding.slice(0, previewLength).join(", ");
+    return `Embedding [${embedding.length}]: [${preview}${embedding.length > previewLength ? ", ..." : ""}]`;
+  }
+
   private async getProviderInfo(
     connectionParams: ConnectionParams,
     testConnection?: boolean
@@ -247,14 +253,10 @@ export class ModelResolver extends BaseResolver {
         model
       );
 
-      const previewLength = 10;
-      const preview = result.embedding.slice(0, previewLength).join(", ");
-      const content = `Embedding [${result.embedding.length}]: [${preview}${result.embedding.length > previewLength ? ", ..." : ""}]`;
-
       return {
         id: "00000000-0000-0000-0000-000000000001",
         role: MessageRole.ASSISTANT,
-        content: content,
+        content: ModelResolver.formatEmbeddingPreview(result.embedding),
         modelId: model.modelId,
         modelName: model.name,
         createdAt: timestamp,
@@ -518,7 +520,7 @@ export class ModelResolver extends BaseResolver {
     const connectionParams = this.loadConnectionParams(context, user);
 
     try {
-      const { endpoint, modelName, protocol, text, modelId } = input;
+      const { endpoint, modelName, protocol, text, modelId, type } = input;
       let { apiKey } = input;
 
       // saved model test
@@ -541,6 +543,28 @@ export class ModelResolver extends BaseResolver {
           protocol: protocol as CustomModelProtocol,
         },
       });
+
+      // Embedding models have no chat endpoint — test them with an embeddings request
+      if (type === ModelType.EMBEDDING) {
+        const result = await this.aiService.getEmbeddings(
+          ApiProvider.CUSTOM_REST_API,
+          connectionParams,
+          {
+            modelId: modelName,
+            input: text,
+          },
+          model
+        );
+
+        return {
+          id: "test-result",
+          role: MessageRole.ASSISTANT,
+          content: ModelResolver.formatEmbeddingPreview(result.embedding),
+          isActive: true,
+          createdAt: new Date(),
+          updatedAt: new Date(),
+        } as Message;
+      }
 
       const request: CompleteChatRequest = {
         apiProvider: ApiProvider.CUSTOM_REST_API,

--- a/api/src/types/graphql/inputs.ts
+++ b/api/src/types/graphql/inputs.ts
@@ -506,6 +506,9 @@ export class TestCustomModelInput {
   @Field()
   modelName: string;
 
+  @Field(() => ModelType, { nullable: true, defaultValue: ModelType.CHAT })
+  type: ModelType;
+
   @Field()
   protocol: string;
 

--- a/client/src/components/models/CustomModelDialog.tsx
+++ b/client/src/components/models/CustomModelDialog.tsx
@@ -147,6 +147,7 @@ export const CustomModelDialog: React.FC<CustomModelDialogProps> = ({
             apiKey: initialData?.apiKey === formData.apiKey ? undefined : formData.apiKey,
             modelName: formData.modelName,
             modelId: formData.modelId,
+            type: formData.type,
             protocol: formData.protocol,
             text: testPrompt || "Hey there!",
           },


### PR DESCRIPTION
## Summary

The **Test Connection** button in the custom model dialog always ran a chat completion (`modelType: CHAT` hardcoded in `testCustomModel`), so Embedding-type models could never pass the test — e.g. an Ollama `bge-m3` has no `/chat/completions` endpoint. The selected **Model Type** from the dialog now flows into the test: for `EMBEDDING` the mutation calls `getEmbeddings` and returns the same vector preview the saved-model test (`testModel`) shows (`Embedding [1024]: [0.0014, …]`); other types keep the chat test unchanged.

## Changes

- **API**: `TestCustomModelInput` gets a `type` field (`ModelType`, defaults to `CHAT` so existing clients keep working); `testCustomModel` routes `EMBEDDING` to an embeddings request against the temporary model; the vector-preview formatting is shared with `testModel` via a small helper.
- **Client**: `CustomModelDialog` passes the selected `type` into the test mutation.

## Testing

- `npm test` (api): 87/87 pass; `tsc --noEmit` clean for api and for the changed client file; prettier clean.

## Notes

Reminder for testing against a local Ollama: the Endpoint URL must be the base URL (`http://localhost:11434/v1`) — the OpenAI SDK appends `/embeddings` / `/chat/completions` itself.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018GfDqRAeCbu2hgFja8Utu9

---
_Generated by [Claude Code](https://claude.ai/code/session_018GfDqRAeCbu2hgFja8Utu9)_