### PR TITLE
Docs audit: stale provider values, missing env vars, README TODO refresh

### DIFF
--- a/README.md
+++ b/README.md
@@ -200,7 +200,7 @@ cargo run
 
 2. Client
 ```bash
-APP_API_URL=http://localhost:4001  APP_WS_URL=http://localhost:4002 npm run dev:client
+APP_API_URL=http://localhost:4000  APP_WS_URL=http://localhost:4001 npm run dev:client
 ```
 
 #### API DB Migrations

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ To interact with all supported AI models in the demo, you'll need to provide you
 - Voice-to-voice conversations with realtime models (OpenAI GPT Realtime over WebRTC, Yandex Speech Realtime over a WebSocket proxy): live equalizer above the chat controls, transcripts saved to chat history, assistant voice selection per chat
 - Voice messages for audio-input models (`gpt-4o-audio`, `gpt-audio`): record from the microphone, stream the text transcript live and play the spoken response inline
 - Client-side Python code [execution](#python-code-run-in-browser) with [Pyodide](https://pyodide.org/) 
-- Reusable [@katechat/ui](https://www.nopepmjs.com/package/@katechat/ui) that includes basic chatbot controls.
+- Reusable [@katechat/ui](https://www.npmjs.com/package/@katechat/ui) that includes basic chatbot controls.
   * Usage examples are available in [examples](examples). 
   * Voice-to-voice demo for OpenAI realtime WebRTC API.
 - External users authentication (email/password, [Google OAuth, GitHub OAuth](/docs/oauth-setup.md))
@@ -70,7 +70,7 @@ To interact with all supported AI models in the demo, you'll need to provide you
 * Use refresh token im MCP, save tokens encoded in Redis for agents
 
 ### APIs
-* (hgh) Rust API sync, part 2: RAG/documents pipeline, MCP tools, web search, chat folders, OpenAI Responses protocol (gpt-5 / native tools), realtime voice, message regeneration on edit. ~~Images generation, Library, admin API, OpenAI protocol for OpenAI/Yandex/Custom models~~ — done.
+* (hgh) Rust API sync, part 3: OpenAI Responses protocol (gpt-5 / native tools), realtime voice, message regeneration on edit (switchModel/callOther), forgot/reset password, global search. ~~Images generation, Library, admin API, OpenAI protocol for OpenAI/Yandex/Custom models~~, ~~RAG/documents pipeline (incl. live statuses over Redis), MCP tools, web search, chat folders~~ — done.
 * (hgh) Google Vertex AI provider support
 * (mid) SerpApi for Web Search (new setting in UI)
 * (mid) Python API (FastAPI)

--- a/api-rust/.env.example
+++ b/api-rust/.env.example
@@ -1,19 +1,37 @@
 #############################  Server Configuration
+# Subscriptions WebSocket server listens on PORT+1 (here: 4002)
 PORT=4001
-NODE_ENV=development
+ENVIRONMENT=development
+LOG_LEVEL=debug
 
 #############################  DB Configuration
-DB_TYPE=sqlite
+# sqlite (bundled) or postgres; api-rust needs its OWN database — do not
+# point it at the Node API's DB (incompatible schemas, see README.md)
+DATABASE_URL=sqlite://katechat.sqlite
+# DATABASE_URL=postgres://katechat:katechat@localhost:5432/katechat_rust
 
-############################# S3 Configuration (Localstack on localhost)
+############################# S3 Configuration (LocalStack on localhost)
 S3_ENDPOINT=http://localhost:4566
-S3_REGION=eu-central-1 # your preferred region ffor AWS S3
+S3_REGION=eu-central-1
 S3_ACCESS_KEY_ID=localstack
 S3_SECRET_ACCESS_KEY=localstack
 S3_FILES_BUCKET_NAME=katechatdevfiles
 
+############################# SQS Configuration (RAG documents pipeline)
+SQS_ENDPOINT=http://localhost:4566
+SQS_REGION=eu-central-1
+SQS_ACCESS_KEY_ID=localstack
+SQS_SECRET_ACCESS_KEY=localstack
+SQS_DOCUMENTS_QUEUE=http://sqs.eu-central-1.localhost.localstack.cloud:4566/000000000000/documents-queue
+SQS_INDEX_DOCUMENTS_QUEUE=http://sqs.eu-central-1.localhost.localstack.cloud:4566/000000000000/documents-index-queue
+
+############################# Redis (live document-processor statuses)
+# Defaults to redis://localhost:6379; set empty to disable the subscriber
+# REDIS_URL=redis://localhost:6379
+# DOCUMENT_STATUS_CHANNEL=document:status
+
 # Format: <provider1>,<provider2>,... or "*"
-ENABLED_API_PROVIDERS=AWS_BEDROCK,OPEN_AI,YANDEX_FM,CUSTOM_REST_API
+ENABLED_API_PROVIDERS=AWS_BEDROCK,OPEN_AI,YANDEX_AI,CUSTOM_REST_API
 
 ############################# Admin Configuration
 DEFAULT_ADMIN_EMAILS=admin@example.com,another-admin@example.com
@@ -26,18 +44,22 @@ DEFAULT_ADMIN_EMAILS=admin@example.com,another-admin@example.com
 
 # OpenAI Configuration
 # OPENAI_API_KEY=your-openai-api-key
-# OPENAI_API_ADMIN_KEY=your-openai-admin-key
 # OPENAI_API_URL=https://api.openai.com/v1
+
+# Yandex Configuration
+# YANDEX_FM_API_KEY=your-yandex-api-key
+# YANDEX_FM_API_FOLDER=your-yandex-folder-id
+# YANDEX_OPENAI_API_URL=https://ai.api.cloud.yandex.net/v1
+
+# Web search tool (Yandex Search API v2; falls back to YANDEX_FM_* creds)
+# YANDEX_SEARCH_API_KEY=your-yandex-search-key
+# YANDEX_SEARCH_API_URL=https://searchapi.api.cloud.yandex.net/v2/web/search
 
 ############################# CORS Configuration
 ALLOWED_ORIGINS=http://localhost:3000
 
 ############################# JWT Secret
 JWT_SECRET=your-jwt-secret
-JWT_EXPIRATION=86400
-
-############################# reCAPTCHA Configuration
-RECAPTCHA_SECRET_KEY=6LeIxAcTAAAAAGG-vFI1TnRWxMZNFuojJ4WifJWe # https://developers.google.com/recaptcha/docs/faq
 
 ############################# OAuth Configuration
 # GOOGLE_OAUTH_CLIENT_ID=your-google-client-id
@@ -45,7 +67,7 @@ RECAPTCHA_SECRET_KEY=6LeIxAcTAAAAAGG-vFI1TnRWxMZNFuojJ4WifJWe # https://develope
 # GITHUB_OAUTH_CLIENT_ID=your-github-client-id
 # GITHUB_OAUTH_CLIENT_SECRET=your-github-client-secret
 # GITHUB_OAUTH_ORGANIZATION=your-github-organization
-# CALLBACK_URL_BASE=http://localhost:4000
+# CALLBACK_URL_BASE=http://localhost:4001
 # FRONTEND_URL=http://localhost:3000
 # SESSION_SECRET=your-session-secret
 
@@ -54,4 +76,3 @@ DEMO_MODE=false
 DEMO_MAX_CHAT_MESSAGES=1000
 DEMO_MAX_CHATS=100
 DEMO_MAX_IMAGES=10
-

--- a/api-rust/.env.example
+++ b/api-rust/.env.example
@@ -1,6 +1,7 @@
 #############################  Server Configuration
-# Subscriptions WebSocket server listens on PORT+1 (here: 4002)
-PORT=4001
+# HTTP API port; the subscriptions WebSocket server listens on PORT+1
+# (here: 4001)
+PORT=4000
 ENVIRONMENT=development
 LOG_LEVEL=debug
 
@@ -67,7 +68,7 @@ JWT_SECRET=your-jwt-secret
 # GITHUB_OAUTH_CLIENT_ID=your-github-client-id
 # GITHUB_OAUTH_CLIENT_SECRET=your-github-client-secret
 # GITHUB_OAUTH_ORGANIZATION=your-github-organization
-# CALLBACK_URL_BASE=http://localhost:4001
+# CALLBACK_URL_BASE=http://localhost:4000
 # FRONTEND_URL=http://localhost:3000
 # SESSION_SECRET=your-session-secret
 

--- a/api-rust/README.md
+++ b/api-rust/README.md
@@ -107,7 +107,7 @@ cargo fmt
 
 Providers are gated by `ENABLED_API_PROVIDERS`
 (`AWS_BEDROCK,OPEN_AI,YANDEX_AI,CUSTOM_REST_API` or `*`). Point the client
-at it with `APP_API_URL=http://localhost:4001 APP_WS_URL=http://localhost:4002`
+at it with `APP_API_URL=http://localhost:4000 APP_WS_URL=http://localhost:4001`
 (see the root README).
 
 CI (`.github/workflows/ci-cd.yml`, job `rust-api`) runs fmt/clippy/tests

--- a/api/.env.example
+++ b/api/.env.example
@@ -14,7 +14,8 @@ S3_SECRET_ACCESS_KEY=localstack
 S3_FILES_BUCKET_NAME=katechatdevfiles
 
 # Format: <provider1>,<provider2>,... or "*"
-ENABLED_API_PROVIDERS=AWS_BEDROCK,OPEN_AI,YANDEX_FM
+# Valid values: AWS_BEDROCK, OPEN_AI, YANDEX_AI, CUSTOM_REST_API
+ENABLED_API_PROVIDERS=AWS_BEDROCK,OPEN_AI,YANDEX_AI
 
 ############################# Admin Configuration
 DEFAULT_ADMIN_EMAILS=admin@example.com,another-admin@example.com
@@ -37,6 +38,11 @@ DEFAULT_ADMIN_EMAILS=admin@example.com,another-admin@example.com
 # YANDEX_FM_API_FOLDER=...
 # YANDEX_AI_IGNORED_MODELS=<comma-separated-list-of-model-names-to-ignore>
 
+# Web search tool (Yandex Search API v2; falls back to YANDEX_FM_* creds)
+# YANDEX_SEARCH_API_KEY=...
+# YANDEX_SEARCH_API_FOLDER=...
+# YANDEX_SEARCH_API_URL=https://searchapi.api.cloud.yandex.net/v2/web/search
+
 ############################# SQS Configuration (for RAG, and other async tasks)
 SQS_ENDPOINT=http://localhost:4566
 SQS_REGION=eu-central-1
@@ -46,6 +52,11 @@ SQS_SECRET_ACCESS_KEY=localstack
 SQS_DOCUMENTS_QUEUE=http://sqs.eu-central-1.localhost.localstack.cloud:4566/000000000000/documents-queue
 SQS_INDEX_DOCUMENTS_QUEUE=http://sqs.eu-central-1.localhost.localstack.cloud:4566/000000000000/documents-index-queue
 SQS_REQUESTS_QUEUE=http://sqs.eu-central-1.localhost.localstack.cloud:4566/000000000000/requests-queue
+
+############################# Redis (subscriptions fan-out, document statuses)
+# Defaults to redis://localhost:6379
+# REDIS_URL=redis://localhost:6379
+# DOCUMENT_STATUS_CHANNEL=document:status
 
 ############################# CORS Configuration
 ALLOWED_ORIGINS=http://localhost:3000

--- a/document-processor/.env.example
+++ b/document-processor/.env.example
@@ -30,6 +30,7 @@ SQS_DOCUMENTS_QUEUE=http://sqs.eu-central-1.localhost.localstack.cloud:4566/0000
 SQS_INDEX_DOCUMENTS_QUEUE=http://sqs.eu-central-1.localhost.localstack.cloud:4566/000000000000/documents-index-queue
 
 REDIS_URL=redis://localhost:6379
+# DOCUMENT_STATUS_CHANNEL=document:status
 
 ############################# Document Processor Configuration
 


### PR DESCRIPTION
## Summary

Documentation correctness pass after the Rust API sync (#150): every claim in the READMEs and `.env.example` files was checked against the code that actually reads it.

## Fixes

### Stale provider values (functional impact)
- `ENABLED_API_PROVIDERS` examples in **api/.env.example** and **api-rust/.env.example** used `YANDEX_FM` — the `ApiProvider` enum value is `YANDEX_AI` in both backends, so copying the example silently disabled the Yandex provider. Fixed, with the valid values documented.

### api-rust/.env.example rewritten against `config.rs`
- `DATABASE_URL` instead of unused `DB_TYPE`; `ENVIRONMENT`/`LOG_LEVEL` instead of unused `NODE_ENV`.
- Removed vars api-rust never reads: `RECAPTCHA_SECRET_KEY`, `JWT_EXPIRATION`, `OPENAI_API_ADMIN_KEY`.
- Added the missing blocks for features shipped in #150: SQS queues (RAG pipeline), Redis status stream (`REDIS_URL`/`DOCUMENT_STATUS_CHANNEL`), Yandex FM credentials, web-search keys (with the `YANDEX_FM_API_KEY` fallback noted).
- Noted the subscriptions WebSocket port (`PORT+1`) and the separate-database requirement.

### api/.env.example
- Documented `REDIS_URL`/`DOCUMENT_STATUS_CHANNEL` (defaults to localhost) and the Yandex Search API web-search keys.

### document-processor/.env.example
- Documented the `DOCUMENT_STATUS_CHANNEL` override.

### README.md
- Fixed the broken `@katechat/ui` npm link (`nopepmjs.com` → `npmjs.com`).
- Updated the Rust API sync TODO to part 3: part 2 (RAG pipeline incl. live Redis statuses, MCP tools, web search, chat folders) is merged; remaining items are the OpenAI Responses protocol, realtime voice, message regeneration, forgot/reset password and global search.

## Verification

- Every env var in the rewritten examples cross-checked against `env::var(...)` reads in `api-rust/src/config.rs` / `process.env` reads in `api/src/global-config.ts`.
- `YANDEX_AI` confirmed as the enum value in both `api/src/types/api.ts` and `api-rust/src/services/ai.rs`.
- api-rust README "Supported" claims spot-checked against resolvers (`refresh_token`, Bedrock `get_costs`, "Not ported yet" list matches missing resolvers).
- document-processor README already matched the code (English OCR default, batching, GPU notes) — no changes needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018GfDqRAeCbu2hgFja8Utu9

---
_Generated by [Claude Code](https://claude.ai/code/session_018GfDqRAeCbu2hgFja8Utu9)_