### PR TITLE
Port password reset, realtime voice, and message regeneration from Node

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ To interact with all supported AI models in the demo, you'll need to provide you
 * Use refresh token im MCP, save tokens encoded in Redis for agents
 
 ### APIs
-* (hgh) Rust API sync, part 3: OpenAI Responses protocol (gpt-5 / native tools), realtime voice, message regeneration on edit (switchModel/callOther), forgot/reset password, global search. ~~Images generation, Library, admin API, OpenAI protocol for OpenAI/Yandex/Custom models~~, ~~RAG/documents pipeline (incl. live statuses over Redis), MCP tools, web search, chat folders~~ — done.
+* (hgh) Rust API sync, part 4: OpenAI native tools (web_search/code_interpreter) on the Responses protocol, per-chat voice/thinking settings persistence, audio-input models. ~~Images generation, Library, admin API, OpenAI protocol~~, ~~RAG pipeline, MCP tools, web search, chat folders~~, ~~Responses protocol, realtime voice, message regeneration, forgot/reset password, global search~~ — done.
 * (hgh) Google Vertex AI provider support
 * (mid) SerpApi for Web Search (new setting in UI)
 * (mid) Python API (FastAPI)

--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ To interact with all supported AI models in the demo, you'll need to provide you
 * Use refresh token im MCP, save tokens encoded in Redis for agents
 
 ### APIs
-* (hgh) Rust API sync, part 4: OpenAI native tools (web_search/code_interpreter) on the Responses protocol, per-chat voice/thinking settings persistence, audio-input models. ~~Images generation, Library, admin API, OpenAI protocol~~, ~~RAG pipeline, MCP tools, web search, chat folders~~, ~~Responses protocol, realtime voice, message regeneration, forgot/reset password, global search~~ — done.
+* (low) Rust API sync — remaining polish: streamed pcm16 audio replies (currently sync), multi-turn audio-context reload from S3. ~~Images generation, Library, admin API, OpenAI protocol~~, ~~RAG pipeline, MCP tools, web search, chat folders~~, ~~Responses protocol, realtime voice, message regeneration, forgot/reset password, global search~~, ~~native OpenAI tools on Responses, per-chat voice/thinking persistence, audio-input models~~ — done.
 * (hgh) Google Vertex AI provider support
 * (mid) SerpApi for Web Search (new setting in UI)
 * (mid) Python API (FastAPI)

--- a/api-rust/Cargo.lock
+++ b/api-rust/Cargo.lock
@@ -1037,7 +1037,7 @@ version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6fac387a98bb7c37292057cffc56d62ecb629900026402633ae9160df93a8766"
 dependencies = [
- "nom",
+ "nom 7.1.3",
 ]
 
 [[package]]
@@ -1058,7 +1058,7 @@ dependencies = [
  "num-traits",
  "serde",
  "wasm-bindgen",
- "windows-link",
+ "windows-link 0.1.3",
 ]
 
 [[package]]
@@ -1120,7 +1120,7 @@ dependencies = [
  "async-trait",
  "convert_case",
  "json5",
- "nom",
+ "nom 7.1.3",
  "pathdiff",
  "ron",
  "rust-ini",
@@ -1644,6 +1644,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "email-encoding"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9298e6504d9b9e780ed3f7dfd43a61be8cd0e09eb07f7706a945b0072b6670b6"
+dependencies = [
+ "base64 0.22.1",
+ "memchr",
+]
+
+[[package]]
+name = "email_address"
+version = "0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e079f19b08ca6239f47f8ba8509c11cf3ea30095831f7fed61441475edd8c449"
+
+[[package]]
 name = "encoding_rs"
 version = "0.8.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2115,6 +2131,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589533453244b0995c858700322199b2becb13b627df2851f64a2775d024abcf"
 dependencies = [
  "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "hostname"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "617aaa3557aef3810a6369d0a99fac8a080891b68bd9f9812a1eeda0c0730cbd"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "windows-link 0.2.1",
 ]
 
 [[package]]
@@ -2624,6 +2651,7 @@ dependencies = [
  "hex",
  "jsonwebtoken",
  "lazy_static",
+ "lettre",
  "libsqlite3-sys",
  "log",
  "multer 3.1.0",
@@ -2666,6 +2694,34 @@ name = "lazycell"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
+
+[[package]]
+name = "lettre"
+version = "0.11.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0da65617f6cb926332d039cb578aad56178da86e128db6a1b09f4c94fa5b3349"
+dependencies = [
+ "async-trait",
+ "base64 0.22.1",
+ "email-encoding",
+ "email_address",
+ "fastrand",
+ "futures-io",
+ "futures-util",
+ "hostname",
+ "httpdate",
+ "idna",
+ "mime",
+ "nom 8.0.0",
+ "percent-encoding",
+ "quoted_printable",
+ "rustls 0.23.27",
+ "socket2 0.6.5",
+ "tokio",
+ "tokio-rustls 0.26.2",
+ "url",
+ "webpki-roots 1.0.9",
+]
 
 [[package]]
 name = "libc"
@@ -2919,6 +2975,15 @@ checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
 dependencies = [
  "memchr",
  "minimal-lexical",
+]
+
+[[package]]
+name = "nom"
+version = "8.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df9761775871bdef83bee530e60050f7e54b1105350d6884eb0fb4f46c2f9405"
+dependencies = [
+ "memchr",
 ]
 
 [[package]]
@@ -3448,6 +3513,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "quoted_printable"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "478e0585659a122aa407eb7e3c0e1fa51b1d8a870038bd29f0cf4a8551eea972"
+
+[[package]]
 name = "r-efi"
 version = "5.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3648,7 +3719,7 @@ dependencies = [
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
- "webpki-roots",
+ "webpki-roots 0.25.4",
  "winreg",
 ]
 
@@ -3937,7 +4008,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "730944ca083c1c233a75c09f199e973ca499344a2b7ba9e755c457e86fb4a321"
 dependencies = [
  "aws-lc-rs",
+ "log",
  "once_cell",
+ "ring",
  "rustls-pki-types",
  "rustls-webpki 0.103.3",
  "subtle",
@@ -4320,6 +4393,16 @@ checksum = "e22376abed350d73dd1cd119b57ffccad95b4e585a7cda43e286245ce23c0678"
 dependencies = [
  "libc",
  "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "socket2"
+version = "0.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3d1e2c7f27f8d4cb10542a02c49005dbd6e93095799d6f3be745fae9f8fedd4"
+dependencies = [
+ "libc",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5231,6 +5314,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5f20c57d8d7db6d3b86154206ae5d8fba62dd39573114de97c2cb0578251f8e1"
 
 [[package]]
+name = "webpki-roots"
+version = "1.0.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7dcd9d09a39985f5344844e66b0c530a33843579125f23e21e9f0f220850f22a"
+dependencies = [
+ "rustls-pki-types",
+]
+
+[[package]]
 name = "which"
 version = "4.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5281,7 +5373,7 @@ checksum = "c0fdd3ddb90610c7638aa2b3a3ab2904fb9e5cdbecc643ddb3647212781c4ae3"
 dependencies = [
  "windows-implement",
  "windows-interface",
- "windows-link",
+ "windows-link 0.1.3",
  "windows-result",
  "windows-strings",
 ]
@@ -5315,12 +5407,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e6ad25900d524eaabdbbb96d20b4311e1e7ae1699af4fb28c17ae66c80d798a"
 
 [[package]]
+name = "windows-link"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
+
+[[package]]
 name = "windows-registry"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b3bab093bdd303a1240bb99b8aba8ea8a69ee19d34c9e2ef9594e708a4878820"
 dependencies = [
- "windows-link",
+ "windows-link 0.1.3",
  "windows-result",
  "windows-strings",
 ]
@@ -5331,7 +5429,7 @@ version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "56f42bd332cc6c8eac5af113fc0c1fd6a8fd2aa08a0119358686e5160d0586c6"
 dependencies = [
- "windows-link",
+ "windows-link 0.1.3",
 ]
 
 [[package]]
@@ -5340,7 +5438,7 @@ version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "56e6c93f3a0c3b36176cb1327a4958a0353d5d166c2a35cb268ace15e91d3b57"
 dependencies = [
- "windows-link",
+ "windows-link 0.1.3",
 ]
 
 [[package]]
@@ -5368,6 +5466,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
 dependencies = [
  "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.61.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
+dependencies = [
+ "windows-link 0.2.1",
 ]
 
 [[package]]

--- a/api-rust/Cargo.toml
+++ b/api-rust/Cargo.toml
@@ -29,6 +29,7 @@ serde_json = "1.0"
 
 # Authentication
 jsonwebtoken = { version = "10.3", features = ["rust_crypto"] }
+lettre = { version = "0.11", default-features = false, features = ["smtp-transport", "tokio1-rustls-tls", "builder", "hostname", "pool"] }
 bcrypt = "0.15"
 
 # HTTP Client

--- a/api-rust/README.md
+++ b/api-rust/README.md
@@ -69,14 +69,30 @@ is assembled from the flat chat columns (fields without a backing column
 — thinking, voice, cacheRetention, … — are accepted but not persisted),
 `mcpEnabled` is true.
 
-## Not ported yet (see the root README TODO)
+- **Message regeneration**: editMessage (delete-following + reuse of the
+  assistant reply, RAG-aware), switchModel (in-place reset with a new
+  model), callOther (linked alternate replies, attached to the thread
+  as `linkedMessages`), updateMessageContent, stopMessageGeneration
+  (in-process cancellation registry + best-effort OpenAI Responses
+  cancel)
+- **Auth extras**: forgotPassword / resetPassword (15-minute JWT reset
+  token, lettre SMTP mailer, optional reCAPTCHA), global `search` over
+  chats/messages/documents (LIKE-based)
+- **OpenAI Responses protocol** (`POST /responses`): automatic for
+  gpt-5 / gpt-4.1 / gpt-4o / o-series models and custom models with
+  `protocol: OPENAI_RESPONSES`; SSE streaming, function-tool loop via
+  `previous_response_id`, request cancellation
+- **Realtime voice**: createRealtimeSession (OpenAI ephemeral WebRTC
+  session, WebSocket-proxy fallback for Yandex on `/realtime/proxy` of
+  the subscriptions server), addChatMessage transcript persistence
 
-Operations of unported features return GraphQL validation errors when
-used: realtime
-voice (createRealtimeSession, addChatMessage), message regeneration
-(switchModel, callOther, updateMessageContent, stopMessageGeneration),
-forgot/reset password, global search, the OpenAI Responses protocol
-(gpt-5 / native tools).
+## Remaining gaps
+
+Per-chat voice/thinking settings have no backing columns (accepted,
+not persisted); OpenAI native tools (web_search/code_interpreter) on
+the Responses protocol are not used — local function tools (Yandex web
+search, MCP) serve both protocols. Client operations validate 53/53
+against the exported SDL (`scripts/validate-client-ops.cjs`).
 
 ## Develop
 

--- a/api-rust/README.md
+++ b/api-rust/README.md
@@ -85,14 +85,27 @@ is assembled from the flat chat columns (fields without a backing column
 - **Realtime voice**: createRealtimeSession (OpenAI ephemeral WebRTC
   session, WebSocket-proxy fallback for Yandex on `/realtime/proxy` of
   the subscriptions server), addChatMessage transcript persistence
+- **Native OpenAI tools on the Responses protocol**: web_search and
+  code_interpreter serialize to provider-native tool blocks (the local
+  Yandex web-search tool is skipped for Responses models); native
+  web_search calls are recorded for the message's tool badges; reasoning
+  effort is derived from the chat's thinking token budget
+- **Per-chat voice + thinking**: persisted in `chats.voice` /
+  `chats.thinking` / `chats.thinking_budget`, surfaced under the chat
+  `settings` object, read by createRealtimeSession, the realtime proxy
+  and the Responses reasoning config
+- **Audio-input models** (`gpt-4o-audio`, `gpt-audio`): voice recordings
+  are stored to S3 and sent as OpenAI `input_audio` blocks; the spoken
+  reply (`modalities:[text,audio]`) is stored to S3 and referenced from
+  the assistant message (chat-completions protocol; sync, not streamed)
 
 ## Remaining gaps
 
-Per-chat voice/thinking settings have no backing columns (accepted,
-not persisted); OpenAI native tools (web_search/code_interpreter) on
-the Responses protocol are not used — local function tools (Yandex web
-search, MCP) serve both protocols. Client operations validate 53/53
-against the exported SDL (`scripts/validate-client-ops.cjs`).
+Audio replies use the non-streaming completion path (no live pcm16
+token streaming); prior-turn voice recordings are not reloaded from S3
+into the model context (only the current turn's audio is sent). Client
+operations validate 53/53 against the exported SDL
+(`scripts/validate-client-ops.cjs`).
 
 ## Develop
 

--- a/api-rust/README.md
+++ b/api-rust/README.md
@@ -103,17 +103,19 @@ is assembled from the flat chat columns (fields without a backing column
   referenced from the message (jsonContent `file` block + link); the
   content is preloaded from S3 and sent to the model as a file block —
   textual mimes inlined as text, PDFs as an OpenAI `file` /
-  `input_file` block (only for image-capable models, Node parity)
+  `input_file` block (OpenAI/Yandex/custom) or a native Anthropic
+  `document` block (Bedrock Claude), only for image-capable models
+  (Node parity)
 
 ## Remaining gaps
 
 Audio replies use the non-streaming completion path (no live pcm16
 token streaming); prior-turn voice recordings are not reloaded from S3
-into the model context (only the current turn's audio is sent). Inline
-file blocks target the OpenAI completions/Responses protocols; the
-Bedrock Converse `document` block is not wired yet. Client operations
-validate 53/53 against the exported SDL
-(`scripts/validate-client-ops.cjs`).
+into the model context (only the current turn's audio is sent).
+Bedrock file blocks cover the Anthropic (Claude) family — the other
+Bedrock model families use their native InvokeModel formats and skip
+non-text files. Client operations validate 53/53 against the exported
+SDL (`scripts/validate-client-ops.cjs`).
 
 ## Develop
 

--- a/api-rust/README.md
+++ b/api-rust/README.md
@@ -106,6 +106,16 @@ is assembled from the flat chat columns (fields without a backing column
   `input_file` block (OpenAI/Yandex/custom) or a native Anthropic
   `document` block (Bedrock Claude), only for image-capable models
   (Node parity)
+- **Model capability flags** (`Model.features`): providers classify each
+  model into the Node `ModelFeature` set surfaced to the client —
+  `REQUEST_CANCELLATION` / `CACHE_RETENTION` (OpenAI Responses models),
+  `REASONING` (gpt-5 / o-series; Bedrock Claude 3.7/4/5), `AUDIO_INPUT` +
+  `AUDIO_OUTPUT` (gpt-4o-audio family), `TEMPERATURE`, and `FILES_INPUT`
+  (chat models on the Responses API or with image input; Bedrock Claude
+  document models). These drive the client's per-model affordances (the
+  document-type upload dialog, the voice-input UI) and are persisted on
+  `reloadModels`. Bedrock advertises `FILES_INPUT` only for the Anthropic
+  (Claude) family, matching the implemented native document blocks
 
 ## Remaining gaps
 

--- a/api-rust/README.md
+++ b/api-rust/README.md
@@ -98,13 +98,21 @@ is assembled from the flat chat columns (fields without a backing column
   are stored to S3 and sent as OpenAI `input_audio` blocks; the spoken
   reply (`modalities:[text,audio]`) is stored to S3 and referenced from
   the assistant message (chat-completions protocol; sync, not streamed)
+- **Inline chat-context files** (PDF/text attached to a turn, distinct
+  from RAG documents): stored to S3 as `inline_document` chat files and
+  referenced from the message (jsonContent `file` block + link); the
+  content is preloaded from S3 and sent to the model as a file block —
+  textual mimes inlined as text, PDFs as an OpenAI `file` /
+  `input_file` block (only for image-capable models, Node parity)
 
 ## Remaining gaps
 
 Audio replies use the non-streaming completion path (no live pcm16
 token streaming); prior-turn voice recordings are not reloaded from S3
-into the model context (only the current turn's audio is sent). Client
-operations validate 53/53 against the exported SDL
+into the model context (only the current turn's audio is sent). Inline
+file blocks target the OpenAI completions/Responses protocols; the
+Bedrock Converse `document` block is not wired yet. Client operations
+validate 53/53 against the exported SDL
 (`scripts/validate-client-ops.cjs`).
 
 ## Develop

--- a/api-rust/README.md
+++ b/api-rust/README.md
@@ -159,5 +159,10 @@ Providers are gated by `ENABLED_API_PROVIDERS`
 at it with `APP_API_URL=http://localhost:4000 APP_WS_URL=http://localhost:4001`
 (see the root README).
 
+`MAX_INPUT_JSON` caps the GraphQL request body (Node parity, default `50mb`;
+accepts `50mb` / `512kb` / `1gb` / a bare byte count). Rocket's built-in
+GraphQL limit is only 128 KiB, so without this inline file/image uploads
+(base64 in `createMessage`) are rejected with a 400 before the resolver runs.
+
 CI (`.github/workflows/ci-cd.yml`, job `rust-api`) runs fmt/clippy/tests
 on every change under `api-rust/**`.

--- a/api-rust/migrations/2026-07-24-000004_chat_voice_thinking/down.sql
+++ b/api-rust/migrations/2026-07-24-000004_chat_voice_thinking/down.sql
@@ -1,0 +1,3 @@
+ALTER TABLE chats DROP COLUMN thinking_budget;
+ALTER TABLE chats DROP COLUMN thinking;
+ALTER TABLE chats DROP COLUMN voice;

--- a/api-rust/migrations/2026-07-24-000004_chat_voice_thinking/up.sql
+++ b/api-rust/migrations/2026-07-24-000004_chat_voice_thinking/up.sql
@@ -1,0 +1,5 @@
+-- Per-chat realtime voice + reasoning (thinking) settings persistence.
+-- Node stores these in the chat's settings JSON; api-rust keeps flat columns.
+ALTER TABLE chats ADD COLUMN voice VARCHAR(64);
+ALTER TABLE chats ADD COLUMN thinking BOOLEAN NOT NULL DEFAULT FALSE;
+ALTER TABLE chats ADD COLUMN thinking_budget INTEGER;

--- a/api-rust/scripts/validate-client-ops.cjs
+++ b/api-rust/scripts/validate-client-ops.cjs
@@ -1,0 +1,43 @@
+// Validate every client GraphQL operation against api-rust's exported
+// SDL. Usage: cargo test export_sdl && cd ../client && node ../api-rust/scripts/validate-client-ops.cjs
+const fs = require('fs');
+const { buildSchema, parse, validate } = require('graphql');
+
+const schema = buildSchema(fs.readFileSync('../api-rust/target/schema.graphql', 'utf8'));
+const src = fs.readFileSync('src/store/services/graphql.queries.ts', 'utf8');
+
+const consts = {};
+for (const m of src.matchAll(/export const (\w+)(?::[^=]+)? = (?:gql)?`([\s\S]*?)`;/g)) {
+  consts[m[1]] = m[2];
+}
+const resolve = (text, seen) => text.replace(/\$\{(\w+)\}/g, (_, name) => {
+  if (!consts[name] || seen.has(name)) return '';
+  seen.add(name);
+  return resolve(consts[name], seen);
+});
+
+const allFragments = Object.entries(consts)
+  .filter(([k, v]) => k.includes('FRAGMENT') && v.trim().startsWith('fragment'))
+  .map(([, v]) => resolve(v, new Set()))
+  .join('\n');
+
+const fragmentDefs = Object.entries(consts)
+  .filter(([k, v]) => k.includes('FRAGMENT') && v.trim().startsWith('fragment'))
+  .map(([, v]) => resolve(v, new Set()));
+
+let fail = 0, total = 0;
+for (const [name, raw] of Object.entries(consts)) {
+  let body = resolve(raw, new Set());
+  for (const frag of fragmentDefs) {
+    const fname = frag.match(/fragment (\w+)/)[1];
+    if (!new RegExp('fragment ' + fname + '\\b').test(body)) body += '\n' + frag;
+  }
+  const m = body.match(/(query|mutation|subscription)\s+(\w+)/);
+  if (!m) continue;
+  total++;
+  try {
+    const errors = validate(schema, parse(body)).filter(e => !/is never used/.test(e.message));
+    if (errors.length) { fail++; console.log('FAIL', m[2], '::', errors[0].message); }
+  } catch (e) { fail++; console.log('PARSE-FAIL', m[2], e.message.slice(0, 90)); }
+}
+console.log(`${total - fail}/${total} operations valid`);

--- a/api-rust/src/config.rs
+++ b/api-rust/src/config.rs
@@ -62,6 +62,16 @@ pub struct AppConfig {
     pub redis_url: Option<String>,
     pub document_status_channel: String,
 
+    // SMTP (password reset emails)
+    pub smtp_host: Option<String>,
+    pub smtp_port: u16,
+    pub smtp_secure: bool,
+    pub smtp_user: Option<String>,
+    pub smtp_password: Option<String>,
+    pub smtp_from: String,
+    pub jwt_reset_password_secret: String,
+    pub recaptcha_secret_key: Option<String>,
+
     // Enabled API providers
     pub enabled_api_providers: Vec<String>,
 }
@@ -106,6 +116,25 @@ impl AppConfig {
             sqs_secret_access_key: env::var("SQS_SECRET_ACCESS_KEY").ok(),
             sqs_documents_queue: env::var("SQS_DOCUMENTS_QUEUE").ok(),
             sqs_index_documents_queue: env::var("SQS_INDEX_DOCUMENTS_QUEUE").ok(),
+
+            // SMTP (Node parity: enabled when SMTP_HOST is set)
+            smtp_host: env::var("SMTP_HOST").ok().filter(|s| !s.is_empty()),
+            smtp_port: env::var("SMTP_PORT")
+                .ok()
+                .and_then(|p| p.parse().ok())
+                .unwrap_or(587),
+            smtp_secure: env::var("SMTP_SECURE")
+                .map(|v| v == "true")
+                .unwrap_or(false),
+            smtp_user: env::var("SMTP_USER").ok(),
+            smtp_password: env::var("SMTP_PASSWORD").ok(),
+            smtp_from: env::var("SMTP_FROM")
+                .unwrap_or_else(|_| "no-reply@katechat.tech".to_string()),
+            jwt_reset_password_secret: env::var("JWT_RESET_PASSWORD_SECRET")
+                .unwrap_or_else(|_| "jwt-reset-password-secret".to_string()),
+            recaptcha_secret_key: env::var("RECAPTCHA_SECRET_KEY")
+                .ok()
+                .filter(|s| !s.is_empty()),
 
             // Redis: siblings (Node API, document-processor) default to
             // localhost; empty REDIS_URL disables the status subscriber

--- a/api-rust/src/config.rs
+++ b/api-rust/src/config.rs
@@ -74,6 +74,11 @@ pub struct AppConfig {
 
     // Enabled API providers
     pub enabled_api_providers: Vec<String>,
+
+    /// Max GraphQL request body size in bytes (Node's `MAX_INPUT_JSON`,
+    /// default 50 MiB). Rocket's default GraphQL limit is only 128 KiB, which
+    /// rejects inline file/image uploads with a 400 before the resolver runs.
+    pub max_input_json_bytes: u64,
 }
 
 impl AppConfig {
@@ -176,6 +181,12 @@ impl AppConfig {
             // Enabled API providers
             enabled_api_providers: Self::parse_enabled_providers(),
 
+            // GraphQL body limit (Node's MAX_INPUT_JSON, default 50mb)
+            max_input_json_bytes: env::var("MAX_INPUT_JSON")
+                .ok()
+                .and_then(|v| Self::parse_byte_size(&v))
+                .unwrap_or(50 * 1024 * 1024),
+
             // Default admin emails
             default_admin_emails: match env::var("DEFAULT_ADMIN_EMAILS") {
                 Ok(value) => value.split(',').map(|s| s.trim().to_string()).collect(),
@@ -184,6 +195,31 @@ impl AppConfig {
                 }
             },
         }
+    }
+
+    /// Parse a human byte size like Node's `bytes` lib accepts: `"50mb"`,
+    /// `"512kb"`, `"1gb"`, or a bare byte count `"52428800"`.
+    fn parse_byte_size(value: &str) -> Option<u64> {
+        let v = value.trim().to_lowercase();
+        if v.is_empty() {
+            return None;
+        }
+        let (num, mult) = if let Some(n) = v.strip_suffix("gb") {
+            (n, 1024 * 1024 * 1024)
+        } else if let Some(n) = v.strip_suffix("mb") {
+            (n, 1024 * 1024)
+        } else if let Some(n) = v.strip_suffix("kb") {
+            (n, 1024)
+        } else if let Some(n) = v.strip_suffix('b') {
+            (n, 1)
+        } else {
+            (v.as_str(), 1)
+        };
+        num.trim()
+            .parse::<f64>()
+            .ok()
+            .filter(|n| *n >= 0.0)
+            .map(|n| (n * mult as f64) as u64)
     }
 
     fn parse_enabled_providers() -> Vec<String> {
@@ -284,6 +320,21 @@ impl AppConfig {
 mod tests {
     use super::*;
     use crate::models::JsonUserSettings;
+
+    #[test]
+    fn parses_human_byte_sizes() {
+        assert_eq!(AppConfig::parse_byte_size("50mb"), Some(50 * 1024 * 1024));
+        assert_eq!(AppConfig::parse_byte_size("512kb"), Some(512 * 1024));
+        assert_eq!(AppConfig::parse_byte_size("1gb"), Some(1024 * 1024 * 1024));
+        assert_eq!(AppConfig::parse_byte_size("1024"), Some(1024));
+        assert_eq!(AppConfig::parse_byte_size("2048b"), Some(2048));
+        assert_eq!(
+            AppConfig::parse_byte_size("  10 MB "),
+            Some(10 * 1024 * 1024)
+        );
+        assert_eq!(AppConfig::parse_byte_size(""), None);
+        assert_eq!(AppConfig::parse_byte_size("abc"), None);
+    }
 
     #[test]
     fn user_settings_override_env_credentials() {

--- a/api-rust/src/graphql/mutation.rs
+++ b/api-rust/src/graphql/mutation.rs
@@ -137,6 +137,121 @@ impl Mutation {
         Ok(AuthResponse { token, user })
     }
 
+    /// Send a password-reset email (Node parity: silent success for
+    /// unknown/OAuth-only users to prevent enumeration).
+    async fn forgot_password(
+        &self,
+        ctx: &Context<'_>,
+        input: crate::models::ForgotPasswordInput,
+    ) -> Result<crate::models::ForgotPasswordResponse> {
+        use crate::models::ForgotPasswordResponse;
+        use crate::services::mail;
+
+        let gql_ctx = ctx.data::<GraphQLContext>()?;
+        let config = &gql_ctx.config;
+
+        if let Some(secret) = &config.recaptcha_secret_key {
+            let Some(token) = input.recaptcha_token.as_deref().filter(|t| !t.is_empty()) else {
+                return Err(async_graphql::Error::new("reCAPTCHA token is required"));
+            };
+            if !mail::verify_recaptcha(secret, token).await? {
+                return Err(async_graphql::Error::new("reCAPTCHA verification failed"));
+            }
+        }
+
+        let mut conn = gql_ctx
+            .db_pool
+            .get()
+            .map_err(|e| AppError::Database(e.to_string()))?;
+        let email = input.email.trim().to_string();
+        let found: Option<User> = users::table
+            .filter(users::email.eq(&email))
+            .first::<User>(&mut conn)
+            .optional()
+            .map_err(|e| AppError::Database(e.to_string()))?;
+
+        // Unknown user or OAuth-only account → pretend success
+        let Some(found) = found.filter(|u| u.password.as_deref().is_some_and(|p| !p.is_empty()))
+        else {
+            return Ok(ForgotPasswordResponse {
+                success: true,
+                error: None,
+            });
+        };
+
+        let reset_token = crate::utils::jwt::create_reset_token(
+            &found.id,
+            &found.email,
+            &config.jwt_reset_password_secret,
+        )
+        .map_err(|e| AppError::Internal(e.to_string()))?;
+        let frontend = config
+            .frontend_url
+            .clone()
+            .unwrap_or_else(|| "http://localhost:3000".to_string());
+        let reset_url = format!("{}/reset-password?token={}", frontend, reset_token);
+
+        if !mail::smtp_enabled(config) {
+            info!("SMTP not enabled; password reset URL: {}", reset_url);
+            return Ok(ForgotPasswordResponse {
+                success: false,
+                error: Some("SMTP is not enabled. Cannot send password reset email.".to_string()),
+            });
+        }
+
+        match mail::send_password_reset_email(config, &found.email, &reset_url).await {
+            Ok(()) => Ok(ForgotPasswordResponse {
+                success: true,
+                error: None,
+            }),
+            Err(e) => {
+                error!("Failed to send password reset email: {}", e);
+                Ok(ForgotPasswordResponse {
+                    success: false,
+                    error: Some("Failed to send reset email. Please try again later.".to_string()),
+                })
+            }
+        }
+    }
+
+    /// Set a new password using a reset token and log the user in.
+    async fn reset_password(
+        &self,
+        ctx: &Context<'_>,
+        input: crate::models::ResetPasswordInput,
+    ) -> Result<AuthResponse> {
+        let gql_ctx = ctx.data::<GraphQLContext>()?;
+        let config = &gql_ctx.config;
+
+        let claims =
+            crate::utils::jwt::verify_reset_token(&input.token, &config.jwt_reset_password_secret)
+                .map_err(|_| async_graphql::Error::new("Reset link is invalid or has expired."))?;
+
+        let mut conn = gql_ctx
+            .db_pool
+            .get()
+            .map_err(|e| AppError::Database(e.to_string()))?;
+        let user: User = users::table
+            .filter(users::id.eq(&claims.user_id))
+            .first(&mut conn)
+            .map_err(|_| async_graphql::Error::new("User not found"))?;
+
+        let hashed =
+            bcrypt::hash(&input.new_password, 12).map_err(|e| AppError::Internal(e.to_string()))?;
+        diesel::update(users::table.filter(users::id.eq(&user.id)))
+            .set((
+                users::password.eq(&hashed),
+                users::updated_at.eq(Utc::now().naive_utc()),
+            ))
+            .execute(&mut conn)
+            .map_err(|e| AppError::Database(e.to_string()))?;
+
+        let token = crate::utils::jwt::create_token(&user.id, &config.jwt_secret)
+            .map_err(|e| AppError::Internal(e.to_string()))?;
+        log_user_action!(&user.id, "reset_password", email = %user.email);
+        Ok(AuthResponse { token, user })
+    }
+
     /// Update user information
     async fn update_user(&self, ctx: &Context<'_>, input: UpdateUserInput) -> Result<User> {
         let gql_ctx = ctx.data::<GraphQLContext>()?;

--- a/api-rust/src/graphql/mutation.rs
+++ b/api-rust/src/graphql/mutation.rs
@@ -958,48 +958,25 @@ impl Mutation {
                 document_ids,
                 input.temperature,
                 input.max_tokens,
+                None,
             )
             .await;
         }
 
-        // Load previous messages for context (up to 100 messages)
+        // Load previous messages for context (up to 100 messages);
+        // linked alternate replies (callOther) are excluded (Node parity)
         const CONTEXT_MESSAGES_LIMIT: i64 = 100;
-
         let previous_messages: Vec<Message> = messages::table
             .filter(messages::chat_id.eq(&input.chat_id))
+            .filter(messages::linked_to_message_id.is_null())
             .order(messages::created_at.desc())
             .limit(CONTEXT_MESSAGES_LIMIT)
             .load(&mut conn)
             .map_err(|e| AppError::Database(e.to_string()))?;
 
-        // Reverse to chronological order and add current user message
         let mut input_messages = previous_messages;
         input_messages.reverse();
         input_messages.push(message.clone());
-
-        // Convert database messages to AI service format and preprocess
-        let model_messages = preprocess_messages(convert_messages_to_model_format(&input_messages));
-
-        // Tools enabled on this chat (web search / MCP servers)
-        let executable_tools = build_chat_tools(
-            &mut conn,
-            &effective_config,
-            &user.id,
-            chat.tools.as_deref(),
-            input.mcp_tokens.as_deref(),
-        )
-        .await;
-
-        // Create invoke request with preprocessed message context
-        let invoke_request = crate::services::ai::InvokeModelRequest {
-            model_id: model_id.clone(),
-            messages: model_messages,
-            temperature: input.temperature,
-            max_tokens: input.max_tokens,
-            top_p: input.top_p,
-            system_prompt: user.default_system_prompt.clone(),
-            tools: (!executable_tools.is_empty()).then_some(executable_tools),
-        };
 
         let ai_msg_data = Message::new(
             input.chat_id.clone(),
@@ -1014,174 +991,21 @@ impl Mutation {
             .get_result::<Message>(&mut conn)
             .map_err(|e| AppError::Database(e.to_string()))?;
 
-        // Create a thread-safe accumulator for all tokens
-        let accumulated_content = Arc::new(Mutex::new(String::new()));
-
-        let callbacks = StreamCallbacks {
-            on_token: |token: String| {
-                let pubsub = pubsub.clone();
-                let chat_id = input.chat_id.clone();
-                let mut ai_message_pub = ai_message.clone();
-                let accumulated_content = accumulated_content.clone();
-
-                // Accumulate tokens in a thread-safe way
-                if let Ok(mut content) = accumulated_content.lock() {
-                    content.push_str(&token);
-                    // Update the message with accumulated content
-                    ai_message_pub.content = content.clone();
-                }
-
-                Box::pin(async move {
-                    let pub_message = message::GqlNewMessage {
-                        r#type: String::from(message::MessageType::Message),
-                        error: None,
-                        message: Some(GqlMessage::from(ai_message_pub)),
-                        streaming: Some(true),
-                        chat: None,
-                    };
-
-                    if let Err(e) = pubsub.publish_to_chat(&chat_id, pub_message).await {
-                        warn!("Failed to publish message to subscribers: {:?}", e);
-                    }
-                })
-            },
-            on_error: |error: AppError| {
-                let pubsub = pubsub.clone();
-                let chat_id = input.chat_id.clone();
-                let error_message = format!("Model inference error: {:?}", error);
-
-                let mut conn_cb = match gql_ctx
-                    .db_pool
-                    .get()
-                    .map_err(|e| AppError::Database(e.to_string()))
-                {
-                    Ok(conn) => conn,
-                    Err(e) => {
-                        error!(
-                            "Failed to get database connection in error callback: {:?}",
-                            e
-                        );
-                        return Box::pin(async move {
-                            let pub_message = message::GqlNewMessage {
-                                r#type: String::from(message::MessageType::Message),
-                                error: Some(format!("Database connection error: {:?}", e)),
-                                message: None,
-                                streaming: Some(false),
-                                chat: None,
-                            };
-
-                            if let Err(e) = pubsub.publish_to_chat(&chat_id, pub_message).await {
-                                warn!("Failed to publish error to subscribers: {:?}", e);
-                            }
-                        });
-                    }
-                };
-
-                // Update message in database with error
-                let _ = diesel::update(messages::table.filter(messages::id.eq(&ai_message.id)))
-                    .set((
-                        messages::content.eq(error_message.clone()),
-                        messages::role.eq(String::from(MessageRole::Error)),
-                        messages::updated_at.eq(Utc::now().naive_utc()),
-                    ))
-                    .execute(&mut conn_cb)
-                    .map_err(|e| {
-                        error!("Failed to write error message: {:?}", e);
-                    });
-
-                let mut error_ai_message = ai_message.clone();
-                error_ai_message.content = error_message;
-                error_ai_message.role = String::from(MessageRole::Error);
-
-                Box::pin(async move {
-                    let pub_message: GqlNewMessage = message::GqlNewMessage {
-                        r#type: String::from(message::MessageType::Message),
-                        error: error_ai_message.content.clone().into(),
-                        message: Some(GqlMessage::from(error_ai_message)),
-                        streaming: Some(false),
-                        chat: None,
-                    };
-
-                    if let Err(e) = pubsub.publish_to_chat(&chat_id, pub_message).await {
-                        warn!("Failed to publish message to subscribers: {:?}", e);
-                    }
-                })
-            },
-
-            on_complete: |content: String| {
-                let pubsub = pubsub.clone();
-                let chat_id = input.chat_id.clone();
-
-                let mut conn_cb = match gql_ctx
-                    .db_pool
-                    .get()
-                    .map_err(|e| AppError::Database(e.to_string()))
-                {
-                    Ok(conn) => conn,
-                    Err(e) => {
-                        error!(
-                            "Failed to get database connection in complete callback: {:?}",
-                            e
-                        );
-                        return Box::pin(async move {
-                            let pub_message = message::GqlNewMessage {
-                                r#type: String::from(message::MessageType::Message),
-                                error: Some(format!("Database connection error: {:?}", e)),
-                                message: None,
-                                streaming: Some(false),
-                                chat: None,
-                            };
-                            if let Err(e) = pubsub.publish_to_chat(&chat_id, pub_message).await {
-                                warn!("Failed to publish error to subscribers: {:?}", e);
-                            }
-                        });
-                    }
-                };
-
-                // Update message in database
-                let _ = diesel::update(messages::table.filter(messages::id.eq(&ai_message.id)))
-                    .set((
-                        messages::content.eq(content.clone()),
-                        messages::updated_at.eq(Utc::now().naive_utc()),
-                    ))
-                    .execute(&mut conn_cb)
-                    .map_err(|e| {
-                        error!("Failed to write assistant message: {:?}", e);
-                    });
-
-                let mut res_ai_message = ai_message.clone();
-                res_ai_message.content = content;
-
-                Box::pin(async move {
-                    let pub_message: GqlNewMessage = message::GqlNewMessage {
-                        r#type: String::from(message::MessageType::Message),
-                        error: None,
-                        message: Some(GqlMessage::from(res_ai_message)),
-                        streaming: Some(false),
-                        chat: None,
-                    };
-
-                    if let Err(e) = pubsub.publish_to_chat(&chat_id, pub_message).await {
-                        warn!("Failed to publish message to subscribers: {:?}", e);
-                    }
-                })
-            },
-        };
-
-        let executed_tools = provider
-            .invoke_model_stream(invoke_request, callbacks)
-            .await
-            .map_err(|e| AppError::Internal(e.to_string()))?;
-
-        // Record tool activity in the assistant message metadata (Node's
-        // toolCalls/tools) and re-publish so the client shows tool badges.
-        if !executed_tools.is_empty() {
-            if let Err(e) =
-                record_tool_metadata(gql_ctx, &input.chat_id, &ai_message.id, &executed_tools).await
-            {
-                warn!("Failed to record tool metadata: {:?}", e);
-            }
-        }
+        stream_reply(
+            gql_ctx,
+            &effective_config,
+            &provider,
+            &chat,
+            &model,
+            input_messages,
+            ai_message,
+            input.temperature,
+            input.max_tokens,
+            input.top_p,
+            user.default_system_prompt.clone(),
+            input.mcp_tokens.as_deref(),
+        )
+        .await?;
 
         Ok(GqlMessage::from(message))
     }
@@ -1247,13 +1071,15 @@ impl Mutation {
 
     /// Edit a message and regenerate following messages
     #[instrument(skip(self, ctx, message_id), fields(user_id = tracing::field::Empty))]
+    /// Edit a user message and regenerate the reply (Node's editMessage:
+    /// deletes following messages, reuses the first following assistant
+    /// message as the regeneration target).
     async fn edit_message(
         &self,
         ctx: &Context<'_>,
-        message_id: async_graphql::ID,
+        #[graphql(name = "messageId")] message_id: async_graphql::ID,
         content: String,
-        // accepted for schema compatibility; MCP tokens are unused until MCP is ported
-        #[graphql(name = "messageContext")] _message_context: Option<
+        #[graphql(name = "messageContext")] message_context: Option<
             crate::models::MessageContextInput,
         >,
     ) -> Result<EditMessageResponse> {
@@ -1264,61 +1090,333 @@ impl Mutation {
             .db_pool
             .get()
             .map_err(|e| AppError::Database(e.to_string()))?;
+        let pubsub = get_global_pubsub();
 
-        tracing::Span::current().record("user_id", &user.id);
-        info!("Editing message {} for user {}", message_id, user.id);
-
-        // Get the message to edit
-        let message: Message = messages::table
+        let loaded: std::result::Result<(Message, Chat), _> = messages::table
+            .inner_join(chats::table)
             .filter(messages::id.eq(&message_id))
-            .filter(
-                messages::user_id
-                    .eq(&user.id)
-                    .or(messages::user_id.is_null()),
-            )
-            .first(&mut conn)
-            .map_err(|_| async_graphql::Error::new("Message not found"))?;
-
-        // Only user messages can be edited
-        if message.role != String::from(MessageRole::User) {
+            .filter(chats::user_id.eq(&user.id))
+            .first(&mut conn);
+        let Ok((mut original, chat)) = loaded else {
             return Ok(EditMessageResponse {
                 message: None,
-                error: Some("Only user messages can be edited".to_string()),
+                error: Some("Message not found".to_string()),
+            });
+        };
+
+        // Editing an assistant message means "reset from the user message
+        // before it", keeping that message's content (Node parity)
+        let mut new_content = content.trim().to_string();
+        if original.role != String::from(MessageRole::User) {
+            let prior_user: Option<Message> = messages::table
+                .filter(messages::chat_id.eq(&chat.id))
+                .filter(messages::created_at.lt(original.created_at))
+                .filter(messages::role.eq(String::from(MessageRole::User)))
+                .order(messages::created_at.desc())
+                .first(&mut conn)
+                .optional()
+                .map_err(|e| AppError::Database(e.to_string()))?;
+            let Some(prior) = prior_user else {
+                return Ok(EditMessageResponse {
+                    message: None,
+                    error: Some("Only user messages can be edited".to_string()),
+                });
+            };
+            new_content = prior.content.clone();
+            original = prior;
+        }
+
+        // Messages after the edited one: reuse the first assistant reply
+        // as the regeneration target, delete the rest (and their files)
+        let following: Vec<Message> = messages::table
+            .filter(messages::chat_id.eq(&chat.id))
+            .filter(messages::id.ne(&original.id))
+            .filter(messages::created_at.ge(original.created_at))
+            .order(messages::created_at.asc())
+            .load(&mut conn)
+            .map_err(|e| AppError::Database(e.to_string()))?;
+
+        let reused = following
+            .iter()
+            .find(|m| m.role == String::from(MessageRole::Assistant))
+            .cloned();
+        let document_ids = reused
+            .as_ref()
+            .and_then(|m| m.parsed_metadata())
+            .and_then(|m| m.document_ids)
+            .or_else(|| original.parsed_metadata().and_then(|m| m.document_ids))
+            .filter(|ids| !ids.is_empty());
+
+        let delete_ids: Vec<String> = following
+            .iter()
+            .filter(|m| Some(&m.id) != reused.as_ref().map(|r| &r.id))
+            .map(|m| m.id.clone())
+            .collect();
+        if !delete_ids.is_empty() {
+            let _ = diesel::delete(
+                chat_files::table.filter(chat_files::message_id.eq_any(&delete_ids)),
+            )
+            .execute(&mut conn);
+            diesel::delete(messages::table.filter(messages::id.eq_any(&delete_ids)))
+                .execute(&mut conn)
+                .map_err(|e| AppError::Database(e.to_string()))?;
+        }
+
+        // Update the user message and publish it
+        let updated: Message =
+            diesel::update(messages::table.filter(messages::id.eq(&original.id)))
+                .set((
+                    messages::content.eq(&new_content),
+                    messages::json_content.eq(None::<String>),
+                    messages::updated_at.eq(Utc::now().naive_utc()),
+                ))
+                .get_result(&mut conn)
+                .map_err(|e| AppError::Database(e.to_string()))?;
+        publish_message(pubsub, &chat.id, &updated, true).await;
+
+        // Resolve model: the chat's model (regeneration keeps it)
+        let model_id = updated
+            .model_id
+            .clone()
+            .or_else(|| chat.model_id.clone())
+            .unwrap_or_default();
+        let model: Model = models::table
+            .filter(models::model_id.eq(&model_id))
+            .filter(models::user_id.eq(&user.id))
+            .first(&mut conn)
+            .map_err(|_| async_graphql::Error::new("Model not found"))?;
+
+        // Reuse or create the assistant target message
+        let ai_message = prepare_regeneration_target(&mut conn, &chat.id, reused, &model, None)?;
+        publish_message(pubsub, &chat.id, &ai_message, true).await;
+
+        let response_message = ai_message.clone();
+        regenerate_reply(
+            gql_ctx,
+            user,
+            &chat,
+            &model,
+            &updated,
+            ai_message,
+            document_ids,
+            message_context.as_ref(),
+        )
+        .await?;
+
+        Ok(EditMessageResponse {
+            message: Some(GqlMessage::from(response_message)),
+            error: None,
+        })
+    }
+
+    /// Regenerate an assistant message with a different model (Node's
+    /// switchModel: resets the message in place).
+    async fn switch_model(
+        &self,
+        ctx: &Context<'_>,
+        #[graphql(name = "messageId")] message_id: async_graphql::ID,
+        #[graphql(name = "modelId")] model_id: String,
+        #[graphql(name = "messageContext")] message_context: Option<
+            crate::models::MessageContextInput,
+        >,
+    ) -> Result<crate::models::SwitchModelResponse> {
+        use crate::models::SwitchModelResponse;
+        let message_id = message_id.to_string();
+        let gql_ctx = ctx.data::<GraphQLContext>()?;
+        let user = gql_ctx.require_user()?;
+        let mut conn = gql_ctx
+            .db_pool
+            .get()
+            .map_err(|e| AppError::Database(e.to_string()))?;
+        let pubsub = get_global_pubsub();
+
+        let loaded: std::result::Result<(Message, Chat), _> = messages::table
+            .inner_join(chats::table)
+            .filter(messages::id.eq(&message_id))
+            .filter(chats::user_id.eq(&user.id))
+            .first(&mut conn);
+        let Ok((original, chat)) = loaded else {
+            return Ok(SwitchModelResponse {
+                message: None,
+                error: Some("Message not found".to_string()),
+            });
+        };
+        if original.role == String::from(MessageRole::User) {
+            return Ok(SwitchModelResponse {
+                message: None,
+                error: Some("Only assistant messages can be switched".to_string()),
             });
         }
 
-        // Delete all messages after this one in the same chat
-        let deleted_count = diesel::delete(
-            messages::table
-                .filter(messages::chat_id.eq(&message.chat_id))
-                .filter(messages::created_at.gt(&message.created_at)),
+        let model: Model = models::table
+            .filter(models::model_id.eq(&model_id))
+            .filter(models::user_id.eq(&user.id))
+            .first(&mut conn)
+            .map_err(|_| async_graphql::Error::new("Model not found"))?;
+
+        // RAG carry-over: last user message's documentIds, else original's
+        let last_user: Option<Message> = messages::table
+            .filter(messages::chat_id.eq(&chat.id))
+            .filter(messages::role.eq(String::from(MessageRole::User)))
+            .filter(messages::created_at.le(original.created_at))
+            .order(messages::created_at.desc())
+            .first(&mut conn)
+            .optional()
+            .map_err(|e| AppError::Database(e.to_string()))?;
+        let document_ids = last_user
+            .as_ref()
+            .and_then(|m| m.parsed_metadata())
+            .and_then(|m| m.document_ids)
+            .or_else(|| original.parsed_metadata().and_then(|m| m.document_ids))
+            .filter(|ids| !ids.is_empty());
+        let trigger = last_user.unwrap_or_else(|| original.clone());
+
+        // Reset the original message in place
+        let ai_message =
+            prepare_regeneration_target(&mut conn, &chat.id, Some(original), &model, None)?;
+        publish_message(pubsub, &chat.id, &ai_message, true).await;
+
+        let response_message = ai_message.clone();
+        regenerate_reply(
+            gql_ctx,
+            user,
+            &chat,
+            &model,
+            &trigger,
+            ai_message,
+            document_ids,
+            message_context.as_ref(),
         )
-        .execute(&mut conn)
-        .map_err(|e| AppError::Database(e.to_string()))?;
+        .await?;
 
-        info!("Deleted {} following messages", deleted_count);
+        Ok(SwitchModelResponse {
+            message: Some(GqlMessage::from(response_message)),
+            error: None,
+        })
+    }
 
-        // Update the message content
-        let updated_message = diesel::update(messages::table.filter(messages::id.eq(&message_id)))
-            .set((
-                messages::content.eq(content.trim()),
-                messages::updated_at.eq(Utc::now().naive_utc()),
-            ))
+    /// Generate an alternate reply with another model, linked to the
+    /// original assistant message (Node's callOther).
+    async fn call_other(
+        &self,
+        ctx: &Context<'_>,
+        #[graphql(name = "messageId")] message_id: async_graphql::ID,
+        #[graphql(name = "modelId")] model_id: String,
+        #[graphql(name = "messageContext")] message_context: Option<
+            crate::models::MessageContextInput,
+        >,
+    ) -> Result<crate::models::CallOtherResponse> {
+        use crate::models::CallOtherResponse;
+        let message_id = message_id.to_string();
+        let gql_ctx = ctx.data::<GraphQLContext>()?;
+        let user = gql_ctx.require_user()?;
+        let mut conn = gql_ctx
+            .db_pool
+            .get()
+            .map_err(|e| AppError::Database(e.to_string()))?;
+        let pubsub = get_global_pubsub();
+
+        let loaded: std::result::Result<(Message, Chat), _> = messages::table
+            .inner_join(chats::table)
+            .filter(messages::id.eq(&message_id))
+            .filter(chats::user_id.eq(&user.id))
+            .first(&mut conn);
+        let Ok((original, chat)) = loaded else {
+            return Ok(CallOtherResponse {
+                message: None,
+                error: Some("Message not found".to_string()),
+            });
+        };
+        if original.role == String::from(MessageRole::User) {
+            return Ok(CallOtherResponse {
+                message: None,
+                error: Some("Only assistant messages can be used".to_string()),
+            });
+        }
+
+        let model: Model = models::table
+            .filter(models::model_id.eq(&model_id))
+            .filter(models::user_id.eq(&user.id))
+            .first(&mut conn)
+            .map_err(|_| async_graphql::Error::new("Model not found"))?;
+
+        // New assistant message linked to the original (alternate reply)
+        let mut linked = Message::new(
+            chat.id.clone(),
+            None,
+            String::new(),
+            String::from(MessageRole::Assistant),
+            model.model_id.clone(),
+            Some(model.name.clone()),
+        );
+        linked.linked_to_message_id = Some(original.id.clone());
+        let ai_message = diesel::insert_into(messages::table)
+            .values(&linked)
             .get_result::<Message>(&mut conn)
             .map_err(|e| AppError::Database(e.to_string()))?;
+        publish_message(pubsub, &chat.id, &ai_message, true).await;
 
-        // TODO: Generate new assistant response here
-        // For now, we'll just return the updated message
-        // In a full implementation, you'd want to:
-        // 1. Get the chat and user's default model
-        // 2. Create a new assistant message
-        // 3. Generate the AI response
+        let response_message = ai_message.clone();
+        regenerate_reply(
+            gql_ctx,
+            user,
+            &chat,
+            &model,
+            &original,
+            ai_message,
+            None,
+            message_context.as_ref(),
+        )
+        .await?;
 
-        let gql_message = GqlMessage::from(updated_message);
-
-        Ok(EditMessageResponse {
-            message: Some(gql_message),
+        Ok(CallOtherResponse {
+            message: Some(GqlMessage::from(response_message)),
             error: None,
+        })
+    }
+
+    /// Stop an in-flight generation (Node's stopMessageGeneration).
+    async fn stop_message_generation(
+        &self,
+        ctx: &Context<'_>,
+        input: crate::models::StopMessageGenerationInput,
+    ) -> Result<crate::models::StopMessageGenerationResponse> {
+        use crate::models::StopMessageGenerationResponse;
+        let gql_ctx = ctx.data::<GraphQLContext>()?;
+        let user = gql_ctx.require_user()?;
+        let mut conn = gql_ctx
+            .db_pool
+            .get()
+            .map_err(|e| AppError::Database(e.to_string()))?;
+
+        let loaded: std::result::Result<(Message, Chat), _> = messages::table
+            .inner_join(chats::table)
+            .filter(messages::id.eq(&input.message_id))
+            .filter(chats::user_id.eq(&user.id))
+            .first(&mut conn);
+        let Ok((message, chat)) = loaded else {
+            return Ok(StopMessageGenerationResponse {
+                error: Some("Message not found".to_string()),
+                request_id: None,
+                message_id: None,
+            });
+        };
+
+        mark_cancelled(&message.id);
+        let mut cancelled = message.clone();
+        cancelled.status = Some("cancelled".to_string());
+        let _ = diesel::update(messages::table.filter(messages::id.eq(&message.id)))
+            .set((
+                messages::status.eq(Some("cancelled".to_string())),
+                messages::updated_at.eq(Utc::now().naive_utc()),
+            ))
+            .execute(&mut conn);
+        publish_message(get_global_pubsub(), &chat.id, &cancelled, false).await;
+
+        Ok(StopMessageGenerationResponse {
+            error: None,
+            request_id: Some(input.request_id),
+            message_id: Some(input.message_id),
         })
     }
 
@@ -2050,6 +2148,323 @@ async fn generate_images_reply(
     Ok(GqlMessage::from(user_message.clone()))
 }
 
+lazy_static::lazy_static! {
+    /// In-process set of message ids whose generation was cancelled
+    /// (Node's MessagesService.cancelledMessages).
+    static ref CANCELLED_MESSAGES: std::sync::Mutex<std::collections::HashSet<String>> =
+        std::sync::Mutex::new(std::collections::HashSet::new());
+}
+
+/// Publish a message to the chat's subscription stream.
+async fn publish_message(
+    pubsub: &crate::services::pubsub::PubSubService,
+    chat_id: &str,
+    message: &Message,
+    streaming: bool,
+) {
+    let pub_message = message::GqlNewMessage {
+        r#type: String::from(message::MessageType::Message),
+        error: None,
+        message: Some(GqlMessage::from(message.clone())),
+        streaming: Some(streaming),
+        chat: None,
+    };
+    if let Err(e) = pubsub.publish_to_chat(chat_id, pub_message).await {
+        warn!("Failed to publish message to subscribers: {:?}", e);
+    }
+}
+
+/// Reset an existing assistant message for regeneration, or create a
+/// fresh placeholder when there is none (Node's editMessage reuse).
+fn prepare_regeneration_target(
+    conn: &mut crate::database::DbConnection,
+    chat_id: &str,
+    existing: Option<Message>,
+    model: &Model,
+    linked_to: Option<String>,
+) -> Result<Message, AppError> {
+    match existing {
+        Some(target) => {
+            let updated: Message =
+                diesel::update(messages::table.filter(messages::id.eq(&target.id)))
+                    .set((
+                        messages::role.eq(String::from(MessageRole::Assistant)),
+                        messages::content.eq(String::new()),
+                        messages::json_content.eq(None::<String>),
+                        messages::metadata.eq(None::<String>),
+                        messages::status.eq(None::<String>),
+                        messages::status_info.eq(None::<String>),
+                        messages::model_id.eq(Some(model.model_id.clone())),
+                        messages::model_name.eq(Some(model.name.clone())),
+                        messages::updated_at.eq(Utc::now().naive_utc()),
+                    ))
+                    .get_result(conn)
+                    .map_err(|e| AppError::Database(e.to_string()))?;
+            Ok(updated)
+        }
+        None => {
+            let mut fresh = Message::new(
+                chat_id.to_string(),
+                None,
+                String::new(),
+                String::from(MessageRole::Assistant),
+                model.model_id.clone(),
+                Some(model.name.clone()),
+            );
+            fresh.linked_to_message_id = linked_to;
+            diesel::insert_into(messages::table)
+                .values(&fresh)
+                .get_result::<Message>(conn)
+                .map_err(|e| AppError::Database(e.to_string()))
+        }
+    }
+}
+
+/// Regenerate a reply into `ai_message`: RAG flow when documentIds are
+/// carried over, otherwise a plain streamed completion with the chat
+/// context up to the trigger message.
+#[allow(clippy::too_many_arguments)]
+async fn regenerate_reply(
+    gql_ctx: &GraphQLContext,
+    user: &User,
+    chat: &Chat,
+    model: &Model,
+    trigger: &Message,
+    ai_message: Message,
+    document_ids: Option<Vec<String>>,
+    message_context: Option<&crate::models::MessageContextInput>,
+) -> Result<(), AppError> {
+    let effective_config = gql_ctx.config.with_user_settings(user.settings.as_ref());
+    let ai_service = AIService::new(effective_config.clone());
+    let provider = ai_service.get_provider_for_model(model)?;
+
+    if let Some(document_ids) = document_ids {
+        generate_rag_reply(
+            gql_ctx,
+            &ai_service,
+            &provider,
+            user,
+            trigger,
+            model,
+            trigger.content.clone(),
+            document_ids,
+            chat.temperature,
+            chat.max_tokens,
+            Some(ai_message),
+        )
+        .await
+        .map_err(|e| AppError::Internal(e.message))?;
+        return Ok(());
+    }
+
+    let mut conn = gql_ctx
+        .db_pool
+        .get()
+        .map_err(|e| AppError::Database(e.to_string()))?;
+    const CONTEXT_MESSAGES_LIMIT: i64 = 100;
+    let mut context: Vec<Message> = messages::table
+        .filter(messages::chat_id.eq(&chat.id))
+        .filter(messages::linked_to_message_id.is_null())
+        .filter(messages::created_at.le(trigger.created_at))
+        .filter(messages::id.ne(&ai_message.id))
+        .order(messages::created_at.desc())
+        .limit(CONTEXT_MESSAGES_LIMIT)
+        .load(&mut conn)
+        .map_err(|e| AppError::Database(e.to_string()))?;
+    context.reverse();
+    drop(conn);
+
+    stream_reply(
+        gql_ctx,
+        &effective_config,
+        &provider,
+        chat,
+        model,
+        context,
+        ai_message,
+        chat.temperature,
+        chat.max_tokens,
+        chat.top_p,
+        user.default_system_prompt.clone(),
+        message_context.and_then(|c| c.mcp_tokens.as_deref()),
+    )
+    .await
+}
+
+fn is_cancelled(message_id: &str) -> bool {
+    CANCELLED_MESSAGES
+        .lock()
+        .map(|s| s.contains(message_id))
+        .unwrap_or(false)
+}
+
+fn mark_cancelled(message_id: &str) {
+    if let Ok(mut set) = CANCELLED_MESSAGES.lock() {
+        set.insert(message_id.to_string());
+    }
+}
+
+/// Stream a model reply into an existing placeholder assistant message.
+/// Shared by createMessage and the regeneration mutations
+/// (editMessage / switchModel / callOther).
+#[allow(clippy::too_many_arguments)]
+async fn stream_reply(
+    gql_ctx: &GraphQLContext,
+    effective_config: &crate::config::AppConfig,
+    provider: &AIProviderWrapper,
+    chat: &Chat,
+    model: &Model,
+    context_messages: Vec<Message>,
+    ai_message: Message,
+    temperature: Option<f32>,
+    max_tokens: Option<i32>,
+    top_p: Option<f32>,
+    system_prompt: Option<String>,
+    mcp_tokens: Option<&[crate::models::McpAuthTokenInput]>,
+) -> Result<(), AppError> {
+    let mut conn = gql_ctx
+        .db_pool
+        .get()
+        .map_err(|e| AppError::Database(e.to_string()))?;
+    let pubsub = get_global_pubsub();
+    let chat_id = chat.id.clone();
+
+    let model_messages = preprocess_messages(convert_messages_to_model_format(&context_messages));
+    let executable_tools = build_chat_tools(
+        &mut conn,
+        effective_config,
+        chat.user_id.as_deref().unwrap_or_default(),
+        chat.tools.as_deref(),
+        mcp_tokens,
+    )
+    .await;
+
+    let invoke_request = crate::services::ai::InvokeModelRequest {
+        model_id: model.model_id.clone(),
+        messages: model_messages,
+        temperature,
+        max_tokens,
+        top_p,
+        system_prompt,
+        tools: (!executable_tools.is_empty()).then_some(executable_tools),
+    };
+
+    let accumulated_content = Arc::new(Mutex::new(String::new()));
+
+    let callbacks = StreamCallbacks {
+        on_token: |token: String| {
+            let pubsub = pubsub.clone();
+            let chat_id = chat_id.clone();
+            let mut ai_message_pub = ai_message.clone();
+            let accumulated_content = accumulated_content.clone();
+            let cancelled = is_cancelled(&ai_message.id);
+
+            if let Ok(mut content) = accumulated_content.lock() {
+                content.push_str(&token);
+                ai_message_pub.content = content.clone();
+            }
+
+            Box::pin(async move {
+                if cancelled {
+                    return; // stop spamming subscribers after a stop request
+                }
+                let pub_message = message::GqlNewMessage {
+                    r#type: String::from(message::MessageType::Message),
+                    error: None,
+                    message: Some(GqlMessage::from(ai_message_pub)),
+                    streaming: Some(true),
+                    chat: None,
+                };
+                if let Err(e) = pubsub.publish_to_chat(&chat_id, pub_message).await {
+                    warn!("Failed to publish message to subscribers: {:?}", e);
+                }
+            })
+        },
+        on_error: |error: AppError| {
+            let pubsub = pubsub.clone();
+            let chat_id = chat_id.clone();
+            let error_message = format!("Model inference error: {:?}", error);
+
+            if let Ok(mut conn_cb) = gql_ctx.db_pool.get() {
+                let _ = diesel::update(messages::table.filter(messages::id.eq(&ai_message.id)))
+                    .set((
+                        messages::content.eq(error_message.clone()),
+                        messages::role.eq(String::from(MessageRole::Error)),
+                        messages::updated_at.eq(Utc::now().naive_utc()),
+                    ))
+                    .execute(&mut conn_cb);
+            }
+
+            let mut error_ai_message = ai_message.clone();
+            error_ai_message.content = error_message;
+            error_ai_message.role = String::from(MessageRole::Error);
+
+            Box::pin(async move {
+                let pub_message: GqlNewMessage = message::GqlNewMessage {
+                    r#type: String::from(message::MessageType::Message),
+                    error: error_ai_message.content.clone().into(),
+                    message: Some(GqlMessage::from(error_ai_message)),
+                    streaming: Some(false),
+                    chat: None,
+                };
+                if let Err(e) = pubsub.publish_to_chat(&chat_id, pub_message).await {
+                    warn!("Failed to publish message to subscribers: {:?}", e);
+                }
+            })
+        },
+        on_complete: |content: String| {
+            let pubsub = pubsub.clone();
+            let chat_id = chat_id.clone();
+            let cancelled = is_cancelled(&ai_message.id);
+            let status = cancelled.then(|| "cancelled".to_string());
+
+            if let Ok(mut conn_cb) = gql_ctx.db_pool.get() {
+                let _ = diesel::update(messages::table.filter(messages::id.eq(&ai_message.id)))
+                    .set((
+                        messages::content.eq(content.clone()),
+                        messages::status.eq(&status),
+                        messages::updated_at.eq(Utc::now().naive_utc()),
+                    ))
+                    .execute(&mut conn_cb);
+            }
+
+            let mut res_ai_message = ai_message.clone();
+            res_ai_message.content = content;
+            res_ai_message.status = status;
+
+            Box::pin(async move {
+                let pub_message: GqlNewMessage = message::GqlNewMessage {
+                    r#type: String::from(message::MessageType::Message),
+                    error: None,
+                    message: Some(GqlMessage::from(res_ai_message)),
+                    streaming: Some(false),
+                    chat: None,
+                };
+                if let Err(e) = pubsub.publish_to_chat(&chat_id, pub_message).await {
+                    warn!("Failed to publish message to subscribers: {:?}", e);
+                }
+            })
+        },
+    };
+
+    let executed_tools = provider
+        .invoke_model_stream(invoke_request, callbacks)
+        .await
+        .map_err(|e| AppError::Internal(e.to_string()))?;
+
+    // Record tool activity in the assistant message metadata (Node's
+    // toolCalls/tools) and re-publish so the client shows tool badges.
+    if !executed_tools.is_empty() {
+        if let Err(e) =
+            record_tool_metadata(gql_ctx, &chat_id, &ai_message.id, &executed_tools).await
+        {
+            warn!("Failed to record tool metadata: {:?}", e);
+        }
+    }
+
+    Ok(())
+}
+
 /// RAG message flow (Node's sendRagMessage): rank the linked documents'
 /// chunks against the question, ask the chat model for a structured
 /// answer and record ragResponse/relevantsChunks metadata.
@@ -2065,6 +2480,7 @@ async fn generate_rag_reply(
     document_ids: Vec<String>,
     temperature: Option<f32>,
     max_tokens: Option<i32>,
+    existing_target: Option<Message>,
 ) -> Result<GqlMessage> {
     use crate::services::rag;
 
@@ -2075,20 +2491,25 @@ async fn generate_rag_reply(
     let pubsub = get_global_pubsub();
     let chat_id = user_message.chat_id.clone();
 
-    // Placeholder assistant message; published as streaming while the
-    // retrieval + completion run
-    let ai_msg_data = Message::new(
-        chat_id.clone(),
-        None,
-        String::new(),
-        String::from(MessageRole::Assistant),
-        user_message.model_id.clone().unwrap_or_default(),
-        Some(model.name.clone()),
-    );
-    let mut ai_message = diesel::insert_into(messages::table)
-        .values(&ai_msg_data)
-        .get_result::<Message>(&mut conn)
-        .map_err(|e| AppError::Database(e.to_string()))?;
+    // Placeholder assistant message (or the regeneration target);
+    // published as streaming while the retrieval + completion run
+    let mut ai_message = match existing_target {
+        Some(target) => target,
+        None => {
+            let ai_msg_data = Message::new(
+                chat_id.clone(),
+                None,
+                String::new(),
+                String::from(MessageRole::Assistant),
+                user_message.model_id.clone().unwrap_or_default(),
+                Some(model.name.clone()),
+            );
+            diesel::insert_into(messages::table)
+                .values(&ai_msg_data)
+                .get_result::<Message>(&mut conn)
+                .map_err(|e| AppError::Database(e.to_string()))?
+        }
+    };
 
     let publish = |message: Message, streaming: bool, error: Option<String>| {
         let pubsub = pubsub.clone();

--- a/api-rust/src/graphql/mutation.rs
+++ b/api-rust/src/graphql/mutation.rs
@@ -1403,6 +1403,34 @@ impl Mutation {
         };
 
         mark_cancelled(&message.id);
+
+        // Best-effort upstream cancellation for OpenAI Responses requests
+        // (requestId is the provider's response id)
+        if let Some(model_id) = message.model_id.as_deref() {
+            if crate::services::openai_responses::uses_responses_api(model_id)
+                && input.request_id.starts_with("resp")
+            {
+                let effective_config = gql_ctx.config.with_user_settings(user.settings.as_ref());
+                let request_id = input.request_id.clone();
+                tokio::spawn(async move {
+                    if let Some(api_key) = effective_config.openai_api_key.clone() {
+                        let protocol =
+                            crate::services::openai_responses::OpenAIResponsesProtocol::new(
+                                crate::services::openai_protocol::OpenAIProtocol::new(
+                                    "https://api.openai.com/v1",
+                                    Some(api_key),
+                                    None,
+                                    "OpenAI",
+                                ),
+                            );
+                        if let Err(e) = protocol.cancel(&request_id).await {
+                            warn!("Responses cancel failed for {}: {}", request_id, e);
+                        }
+                    }
+                });
+            }
+        }
+
         let mut cancelled = message.clone();
         cancelled.status = Some("cancelled".to_string());
         let _ = diesel::update(messages::table.filter(messages::id.eq(&message.id)))

--- a/api-rust/src/graphql/mutation.rs
+++ b/api-rust/src/graphql/mutation.rs
@@ -1207,6 +1207,53 @@ impl Mutation {
         })
     }
 
+    /// Plain content edit without regeneration (Node's
+    /// updateMessageContent; admins may edit any message).
+    async fn update_message_content(
+        &self,
+        ctx: &Context<'_>,
+        #[graphql(name = "messageId")] message_id: async_graphql::ID,
+        content: String,
+    ) -> Result<EditMessageResponse> {
+        let message_id = message_id.to_string();
+        let gql_ctx = ctx.data::<GraphQLContext>()?;
+        let user = gql_ctx.require_user()?;
+        let mut conn = gql_ctx
+            .db_pool
+            .get()
+            .map_err(|e| AppError::Database(e.to_string()))?;
+
+        let result: std::result::Result<(Message, Chat), _> = messages::table
+            .inner_join(chats::table)
+            .filter(messages::id.eq(&message_id))
+            .first(&mut conn);
+        let Ok((message, chat)) = result else {
+            return Ok(EditMessageResponse {
+                message: None,
+                error: Some("Message not found".to_string()),
+            });
+        };
+        if chat.user_id.as_deref() != Some(user.id.as_str()) && user.role != "admin" {
+            return Ok(EditMessageResponse {
+                message: None,
+                error: Some("Unauthorized".to_string()),
+            });
+        }
+
+        let updated: Message = diesel::update(messages::table.filter(messages::id.eq(&message.id)))
+            .set((
+                messages::content.eq(&content),
+                messages::updated_at.eq(Utc::now().naive_utc()),
+            ))
+            .get_result(&mut conn)
+            .map_err(|e| AppError::Database(e.to_string()))?;
+
+        Ok(EditMessageResponse {
+            message: Some(GqlMessage::from(updated)),
+            error: None,
+        })
+    }
+
     /// Reload stored metadata for a chat file (Library). Image-feature
     /// extraction (predominant color, EXIF) is not ported yet, so this
     /// currently returns the stored row as-is.

--- a/api-rust/src/graphql/mutation.rs
+++ b/api-rust/src/graphql/mutation.rs
@@ -1420,6 +1420,133 @@ impl Mutation {
         })
     }
 
+    /// Persist a realtime-voice transcript line without invoking a
+    /// model (Node's addChatMessage).
+    async fn add_chat_message(
+        &self,
+        ctx: &Context<'_>,
+        input: crate::models::AddChatMessageInput,
+    ) -> Result<GqlMessage> {
+        let gql_ctx = ctx.data::<GraphQLContext>()?;
+        let user = gql_ctx.require_user()?;
+        let mut conn = gql_ctx
+            .db_pool
+            .get()
+            .map_err(|e| AppError::Database(e.to_string()))?;
+
+        let role = input.role.to_lowercase();
+        if role != "user" && role != "assistant" {
+            return Err(AppError::Validation("Invalid message role".to_string()).into());
+        }
+        let chat: Chat = chats::table
+            .filter(chats::id.eq(&input.chat_id))
+            .filter(chats::user_id.eq(&user.id))
+            .first(&mut conn)
+            .map_err(|_| async_graphql::Error::new("Chat not found"))?;
+
+        let model_id = chat.model_id.clone().unwrap_or_default();
+        let model_name: Option<String> = models::table
+            .filter(models::model_id.eq(&model_id))
+            .filter(models::user_id.eq(&user.id))
+            .select(models::name)
+            .first(&mut conn)
+            .optional()
+            .map_err(|e| AppError::Database(e.to_string()))?;
+
+        let mut new_message = Message::new(
+            input.chat_id.clone(),
+            (role == "user").then(|| user.id.clone()),
+            input.content.clone(),
+            role.clone(),
+            model_id,
+            (role == "assistant").then(|| model_name.unwrap_or_default()),
+        );
+        if role == "user" {
+            new_message.model_name = None;
+        }
+        let message = diesel::insert_into(messages::table)
+            .values(&new_message)
+            .get_result::<Message>(&mut conn)
+            .map_err(|e| AppError::Database(e.to_string()))?;
+
+        let _ = diesel::update(
+            chats::table
+                .filter(chats::id.eq(&input.chat_id))
+                .filter(chats::is_pristine.eq(true)),
+        )
+        .set(chats::is_pristine.eq(false))
+        .execute(&mut conn);
+
+        publish_message(get_global_pubsub(), &input.chat_id, &message, false).await;
+        Ok(GqlMessage::from(message))
+    }
+
+    /// Mint a realtime voice session: OpenAI ephemeral WebRTC secret, or
+    /// the server-side WebSocket proxy fallback (Yandex / OpenAI errors).
+    async fn create_realtime_session(
+        &self,
+        ctx: &Context<'_>,
+        #[graphql(name = "chatId")] chat_id: async_graphql::ID,
+    ) -> Result<crate::services::realtime::RealtimeSessionResponse> {
+        use crate::services::realtime;
+
+        let chat_id = chat_id.to_string();
+        let gql_ctx = ctx.data::<GraphQLContext>()?;
+        let user = gql_ctx.require_user()?;
+        let mut conn = gql_ctx
+            .db_pool
+            .get()
+            .map_err(|e| AppError::Database(e.to_string()))?;
+
+        let chat: Chat = chats::table
+            .filter(chats::id.eq(&chat_id))
+            .filter(chats::user_id.eq(&user.id))
+            .first(&mut conn)
+            .map_err(|_| async_graphql::Error::new("Chat not found"))?;
+        let model_id = chat
+            .model_id
+            .clone()
+            .or_else(|| user.default_model_id.clone())
+            .ok_or_else(|| async_graphql::Error::new("Chat has no model"))?;
+        let model: Model = models::table
+            .filter(models::model_id.eq(&model_id))
+            .filter(models::user_id.eq(&user.id))
+            .first(&mut conn)
+            .map_err(|_| async_graphql::Error::new("Model not found"))?;
+        if model.type_ != "realtime" {
+            return Err(AppError::Validation(format!(
+                "Model {} is not a realtime model",
+                model.name
+            ))
+            .into());
+        }
+
+        let effective_config = gql_ctx.config.with_user_settings(user.settings.as_ref());
+        let voice = realtime::pick_voice(&model, None);
+
+        if model.api_provider == "OPEN_AI" {
+            match realtime::create_openai_ephemeral_session(&effective_config, &model, &voice).await
+            {
+                Ok(session) => return Ok(session),
+                Err(e) => warn!("OpenAI ephemeral session failed, using WS proxy: {}", e),
+            }
+        }
+
+        let token = crate::utils::jwt::create_realtime_token(
+            &user.id,
+            &chat.id,
+            &gql_ctx.config.jwt_secret,
+        )
+        .map_err(|e| AppError::Internal(e.to_string()))?;
+        Ok(realtime::RealtimeSessionResponse {
+            transport: "websocket".to_string(),
+            model: model.model_id.clone(),
+            client_secret: None,
+            sdp_url: None,
+            ws_url: Some(format!("{}?token={}", realtime::REALTIME_PROXY_PATH, token)),
+        })
+    }
+
     /// Plain content edit without regeneration (Node's
     /// updateMessageContent; admins may edit any message).
     async fn update_message_content(

--- a/api-rust/src/graphql/mutation.rs
+++ b/api-rust/src/graphql/mutation.rs
@@ -886,10 +886,22 @@ impl Mutation {
             new_message.metadata = serde_json::to_string(&metadata).ok();
         }
 
-        let message = diesel::insert_into(messages::table)
+        let mut message = diesel::insert_into(messages::table)
             .values(&new_message)
             .get_result::<Message>(&mut conn)
             .map_err(|e| AppError::Database(e.to_string()))?;
+
+        // A voice recording on the user turn is stored to S3, recorded as a
+        // ChatFile, and referenced from the message (jsonContent + a
+        // markdown link) — same shape as the Node API.
+        if let Some(audio) = input.audio.as_ref().filter(|a| !a.bytes_base64.is_empty()) {
+            let effective_config = gql_ctx.config.with_user_settings(user.settings.as_ref());
+            if let Err(e) =
+                store_input_audio(gql_ctx, &effective_config, &chat, &mut message, audio).await
+            {
+                warn!("Failed to store input audio: {:?}", e);
+            }
+        }
 
         diesel::update(
             chats::table
@@ -981,6 +993,23 @@ impl Mutation {
         let mut input_messages = previous_messages;
         input_messages.reverse();
         input_messages.push(message.clone());
+
+        // Audio-input models (gpt-4o-audio, …) reply with speech; the current
+        // voice recording is sent as an input_audio block and the spoken
+        // reply is stored to S3 (sync, no streaming — Node parity).
+        if crate::services::openai::is_audio_input_model(&model.model_id) {
+            return generate_audio_reply(
+                gql_ctx,
+                &effective_config,
+                &provider,
+                &chat,
+                input_messages,
+                &model,
+                input.audio.as_ref(),
+                user.default_system_prompt.clone(),
+            )
+            .await;
+        }
 
         let ai_msg_data = Message::new(
             input.chat_id.clone(),
@@ -1749,6 +1778,7 @@ impl Mutation {
             native_tools: vec![],
             thinking: None,
             thinking_budget: None,
+            voice: None,
         };
 
         // Test the model
@@ -2022,6 +2052,7 @@ impl Mutation {
                 native_tools: vec![],
                 thinking: None,
                 thinking_budget: None,
+                voice: None,
             };
             service
                 .invoke_model(invoke_request)
@@ -2144,6 +2175,257 @@ impl Mutation {
 
 /// Generate images for an images-generation model and post them as the
 /// assistant reply: upload to S3 under `{chatId}/{messageId}/{uuid}.{ext}`,
+/// Store a user turn's voice recording to S3, record a `chat_files` row and
+/// reference it from the message (jsonContent audio block + a markdown
+/// link) — Node's saveAudioFromBase64 + jsonContent shape.
+async fn store_input_audio(
+    gql_ctx: &GraphQLContext,
+    effective_config: &crate::config::AppConfig,
+    chat: &Chat,
+    message: &mut Message,
+    audio: &crate::models::AudioInput,
+) -> Result<(), AppError> {
+    use base64::Engine;
+    let bytes = base64::engine::general_purpose::STANDARD
+        .decode(audio.bytes_base64.trim())
+        .map_err(|e| AppError::Validation(format!("Invalid audio base64: {}", e)))?;
+    let ext = audio
+        .mime_type
+        .rsplit('/')
+        .next()
+        .filter(|e| !e.is_empty())
+        .unwrap_or("wav");
+    let file_name = format!(
+        "{}/{}/{}.{}",
+        chat.id,
+        message.id,
+        uuid::Uuid::new_v4(),
+        ext
+    );
+
+    let mut s3 = S3Service::new(effective_config.clone());
+    s3.upload_file(&file_name, bytes, &audio.mime_type).await?;
+
+    let mut conn = gql_ctx
+        .db_pool
+        .get()
+        .map_err(|e| AppError::Database(e.to_string()))?;
+    let chat_file = crate::models::ChatFile::new_audio(
+        chat.id.clone(),
+        Some(message.id.clone()),
+        file_name.clone(),
+        audio.mime_type.clone(),
+    );
+    let _ = diesel::insert_into(chat_files::table)
+        .values(&chat_file)
+        .execute(&mut conn);
+
+    let block = serde_json::json!({
+        "contentType": "audio",
+        "fileName": file_name,
+        "mimeType": audio.mime_type,
+        "lengthSec": audio.duration_sec,
+    });
+    message.json_content = Some(serde_json::to_string(&vec![block]).unwrap_or_default());
+    let link = format!(
+        "[Voice message]({})",
+        crate::models::chat_file::file_url(&file_name)
+    );
+    message.content = if message.content.is_empty() {
+        link
+    } else {
+        format!("{}\n\n{}", message.content, link)
+    };
+
+    let updated: Message = diesel::update(messages::table.filter(messages::id.eq(&message.id)))
+        .set((
+            messages::content.eq(&message.content),
+            messages::json_content.eq(&message.json_content),
+            messages::updated_at.eq(Utc::now().naive_utc()),
+        ))
+        .get_result(&mut conn)
+        .map_err(|e| AppError::Database(e.to_string()))?;
+    *message = updated;
+    Ok(())
+}
+
+/// Map an audio mime type to the OpenAI `input_audio` format (wav/mp3);
+/// chat.completions accepts only those two (Node parity).
+fn audio_input_format(mime: &str) -> String {
+    if mime.contains("wav") {
+        "wav".to_string()
+    } else {
+        "mp3".to_string()
+    }
+}
+
+/// Audio-input chat flow (Node's audio path): send the conversation with the
+/// current voice recording as an input_audio block, store the spoken reply
+/// to S3 and reference it from the assistant message.
+#[allow(clippy::too_many_arguments)]
+async fn generate_audio_reply(
+    gql_ctx: &GraphQLContext,
+    effective_config: &crate::config::AppConfig,
+    provider: &AIProviderWrapper,
+    chat: &Chat,
+    context_messages: Vec<Message>,
+    model: &Model,
+    input_audio: Option<&crate::models::AudioInput>,
+    system_prompt: Option<String>,
+) -> Result<GqlMessage> {
+    let mut conn = gql_ctx
+        .db_pool
+        .get()
+        .map_err(|e| AppError::Database(e.to_string()))?;
+    let pubsub = get_global_pubsub();
+
+    // Placeholder assistant message, published as streaming.
+    let ai_msg_data = Message::new(
+        chat.id.clone(),
+        None,
+        String::new(),
+        String::from(MessageRole::Assistant),
+        model.model_id.clone(),
+        Some(model.name.clone()),
+    );
+    let mut ai_message = diesel::insert_into(messages::table)
+        .values(&ai_msg_data)
+        .get_result::<Message>(&mut conn)
+        .map_err(|e| AppError::Database(e.to_string()))?;
+    publish_message(pubsub, &chat.id, &ai_message, true).await;
+
+    // Attach the current recording to the last user turn as an input_audio
+    // block (prior-turn audio is not reloaded from S3 — current turn only).
+    let mut model_messages =
+        preprocess_messages(convert_messages_to_model_format(&context_messages));
+    if let Some(audio) = input_audio.filter(|a| !a.bytes_base64.is_empty()) {
+        if let Some(last_user) = model_messages
+            .iter_mut()
+            .rev()
+            .find(|m| matches!(m.role, crate::services::ai::MessageRole::User))
+        {
+            last_user.audio = Some(crate::services::ai::ModelAudio {
+                data_base64: audio.bytes_base64.trim().to_string(),
+                format: audio_input_format(&audio.mime_type),
+            });
+        }
+    }
+
+    let request = crate::services::ai::InvokeModelRequest {
+        model_id: model.model_id.clone(),
+        messages: model_messages,
+        temperature: chat.temperature,
+        max_tokens: chat.max_tokens,
+        top_p: chat.top_p,
+        system_prompt,
+        tools: None,
+        native_tools: vec![],
+        thinking: None,
+        thinking_budget: None,
+        voice: chat.voice.clone(),
+    };
+
+    let response = match provider.invoke_model(request).await {
+        Ok(response) => response,
+        Err(e) => {
+            let error_message = format!("Model inference error: {}", e);
+            let _ = diesel::update(messages::table.filter(messages::id.eq(&ai_message.id)))
+                .set((
+                    messages::content.eq(&error_message),
+                    messages::role.eq(String::from(MessageRole::Error)),
+                    messages::updated_at.eq(Utc::now().naive_utc()),
+                ))
+                .execute(&mut conn);
+            ai_message.content = error_message;
+            ai_message.role = String::from(MessageRole::Error);
+            publish_message(pubsub, &chat.id, &ai_message, false).await;
+            return Ok(GqlMessage::from(ai_message));
+        }
+    };
+
+    // Store any spoken reply to S3 and reference it from the message.
+    use base64::Engine;
+    let mut content = response.content.clone();
+    let mut blocks: Vec<serde_json::Value> = Vec::new();
+    let mut s3 = S3Service::new(effective_config.clone());
+    for data_url in &response.audios {
+        let (mime, b64) = split_audio_data_url(data_url);
+        let bytes = match base64::engine::general_purpose::STANDARD.decode(b64) {
+            Ok(bytes) => bytes,
+            Err(_) => continue,
+        };
+        let ext = mime
+            .rsplit('/')
+            .next()
+            .filter(|e| !e.is_empty())
+            .unwrap_or("mp3");
+        let ext = if ext == "mpeg" { "mp3" } else { ext };
+        let file_name = format!(
+            "{}/{}/{}.{}",
+            chat.id,
+            ai_message.id,
+            uuid::Uuid::new_v4(),
+            ext
+        );
+        if s3.upload_file(&file_name, bytes, mime).await.is_err() {
+            continue;
+        }
+        let chat_file = crate::models::ChatFile::new_audio(
+            chat.id.clone(),
+            Some(ai_message.id.clone()),
+            file_name.clone(),
+            mime.to_string(),
+        );
+        let _ = diesel::insert_into(chat_files::table)
+            .values(&chat_file)
+            .execute(&mut conn);
+        blocks.push(serde_json::json!({
+            "contentType": "audio",
+            "fileName": file_name,
+            "mimeType": mime,
+        }));
+        let link = format!(
+            "[Voice response]({})",
+            crate::models::chat_file::file_url(&file_name)
+        );
+        content = if content.is_empty() {
+            link
+        } else {
+            format!("{}\n\n{}", content, link)
+        };
+    }
+
+    ai_message.content = content;
+    if !blocks.is_empty() {
+        ai_message.json_content = Some(serde_json::to_string(&blocks).unwrap_or_default());
+    }
+    ai_message.updated_at = Utc::now().naive_utc();
+    let ai_message: Message =
+        diesel::update(messages::table.filter(messages::id.eq(&ai_message.id)))
+            .set((
+                messages::content.eq(&ai_message.content),
+                messages::json_content.eq(&ai_message.json_content),
+                messages::updated_at.eq(ai_message.updated_at),
+            ))
+            .get_result(&mut conn)
+            .map_err(|e| AppError::Database(e.to_string()))?;
+
+    publish_message(pubsub, &chat.id, &ai_message, false).await;
+    Ok(GqlMessage::from(ai_message))
+}
+
+/// Split a `data:audio/xxx;base64,DATA` URL into (mime, base64). Defaults to
+/// audio/mpeg when the prefix is missing.
+fn split_audio_data_url(url: &str) -> (&str, &str) {
+    if let Some(rest) = url.strip_prefix("data:") {
+        if let Some((meta, data)) = rest.split_once(",") {
+            let mime = meta.split(';').next().unwrap_or("audio/mpeg");
+            return (mime, data);
+        }
+    }
+    ("audio/mpeg", url)
+}
+
 /// record a `chat_files` row per image (Library), embed markdown `/files/…`
 /// links + jsonContent blocks in the message — the Node API's
 /// processModelResponse flow.
@@ -2535,6 +2817,7 @@ async fn stream_reply(
         native_tools,
         thinking: Some(chat.thinking),
         thinking_budget: chat.thinking_budget,
+        voice: chat.voice.clone(),
     };
 
     let accumulated_content = Arc::new(Mutex::new(String::new()));
@@ -2772,6 +3055,7 @@ async fn generate_rag_reply(
                 native_tools: vec![],
                 thinking: None,
                 thinking_budget: None,
+                voice: None,
             })
             .await?;
 
@@ -3219,6 +3503,7 @@ fn convert_messages_to_model_format(
             timestamp: Some(msg.created_at.and_utc()),
             tool_calls: None,
             tool_call_id: None,
+            audio: None,
         })
         .collect()
 }

--- a/api-rust/src/graphql/mutation.rs
+++ b/api-rust/src/graphql/mutation.rs
@@ -1033,22 +1033,27 @@ impl Mutation {
             .values(&ai_msg_data)
             .get_result::<Message>(&mut conn)
             .map_err(|e| AppError::Database(e.to_string()))?;
+        // Publish the empty assistant placeholder so the client shows a
+        // pending reply immediately (Node publishes it before streaming).
+        publish_message(pubsub, &input.chat_id, &ai_message, true).await;
+        drop(conn);
 
-        stream_reply(
-            gql_ctx,
-            &effective_config,
-            &provider,
-            &chat,
-            &model,
+        // Stream the reply in the background and return the user message right
+        // away (Node fire-and-forgets streamChatCompletion). Awaiting here kept
+        // the mutation pending for the whole generation.
+        spawn_stream_reply(
+            gql_ctx.clone(),
+            effective_config,
+            chat,
+            model,
             input_messages,
             ai_message,
             input.temperature,
             input.max_tokens,
             input.top_p,
             user.default_system_prompt.clone(),
-            input.mcp_tokens.as_deref(),
-        )
-        .await?;
+            input.mcp_tokens.clone(),
+        );
 
         Ok(GqlMessage::from(message))
     }
@@ -2794,15 +2799,69 @@ fn spawn_regenerate(
         .await
         {
             warn!("Regeneration failed for message {}: {:?}", ai_message_id, e);
-            publish_regeneration_error(&gql_ctx, &chat_id, &ai_message_id, &e).await;
+            publish_stream_error(&gql_ctx, &chat_id, &ai_message_id, &e).await;
         }
     });
 }
 
-/// Turn a still-empty regeneration target into an error message when the
+/// Stream a fresh reply (createMessage's plain chat path) in the background so
+/// the mutation returns immediately (Node fire-and-forgets streamChatCompletion
+/// there too). Awaiting the whole generation kept the createMessage request
+/// pending for the entire response — a minutes-long "hang" for slow reasoning
+/// models or large inline files. The placeholder is published by the caller;
+/// tokens arrive over the subscription.
+#[allow(clippy::too_many_arguments)]
+fn spawn_stream_reply(
+    gql_ctx: GraphQLContext,
+    effective_config: crate::config::AppConfig,
+    chat: Chat,
+    model: Model,
+    input_messages: Vec<Message>,
+    ai_message: Message,
+    temperature: Option<f32>,
+    max_tokens: Option<i32>,
+    top_p: Option<f32>,
+    system_prompt: Option<String>,
+    mcp_tokens: Option<Vec<crate::models::McpAuthTokenInput>>,
+) {
+    let ai_message_id = ai_message.id.clone();
+    let chat_id = chat.id.clone();
+    tokio::spawn(async move {
+        let ai_service = AIService::new(effective_config.clone());
+        let provider = match ai_service.get_provider_for_model(&model) {
+            Ok(p) => p,
+            Err(e) => {
+                warn!("Stream setup failed for message {}: {:?}", ai_message_id, e);
+                publish_stream_error(&gql_ctx, &chat_id, &ai_message_id, &e).await;
+                return;
+            }
+        };
+        if let Err(e) = stream_reply(
+            &gql_ctx,
+            &effective_config,
+            &provider,
+            &chat,
+            &model,
+            input_messages,
+            ai_message,
+            temperature,
+            max_tokens,
+            top_p,
+            system_prompt,
+            mcp_tokens.as_deref(),
+        )
+        .await
+        {
+            warn!("Stream failed for message {}: {:?}", ai_message_id, e);
+            publish_stream_error(&gql_ctx, &chat_id, &ai_message_id, &e).await;
+        }
+    });
+}
+
+/// Turn a still-empty streamed message into an error message when the
 /// background stream fails before its own `on_error` published one (e.g.
 /// provider setup errors), so the client isn't left with a spinner.
-async fn publish_regeneration_error(
+async fn publish_stream_error(
     gql_ctx: &GraphQLContext,
     chat_id: &str,
     message_id: &str,

--- a/api-rust/src/graphql/mutation.rs
+++ b/api-rust/src/graphql/mutation.rs
@@ -347,8 +347,7 @@ impl Mutation {
             .map_err(|e| AppError::Database(e.to_string()))?;
 
         // The client sends generation settings as a nested object (Node API
-        // shape); flat fields are kept for backwards compatibility. Settings
-        // without a backing column (thinking, voice, …) are not persisted.
+        // shape); flat fields are kept for backwards compatibility.
         let settings = input.settings.unwrap_or_default();
         let temperature = settings.temperature.or(input.temperature);
         let max_tokens = settings.max_tokens.or(input.max_tokens);
@@ -382,6 +381,11 @@ impl Mutation {
             top_p.map(|p| chats::top_p.eq(p)),
             settings.system_prompt.map(|s| chats::system_prompt.eq(s)),
             settings.images_count.map(|c| chats::images_count.eq(c)),
+            settings.voice.map(|v| chats::voice.eq(v)),
+            settings.thinking.map(|t| chats::thinking.eq(t)),
+            settings
+                .thinking_budget
+                .map(|b| chats::thinking_budget.eq(b)),
             input.is_pinned.map(|p| chats::is_pinned.eq(p)),
             tools_json.map(|t| chats::tools.eq(t)),
             match &input.folder_id {
@@ -1550,7 +1554,7 @@ impl Mutation {
         }
 
         let effective_config = gql_ctx.config.with_user_settings(user.settings.as_ref());
-        let voice = realtime::pick_voice(&model, None);
+        let voice = realtime::pick_voice(&model, chat.voice.as_deref());
 
         if model.api_provider == "OPEN_AI" {
             match realtime::create_openai_ephemeral_session(&effective_config, &model, &voice).await
@@ -1742,6 +1746,9 @@ impl Mutation {
             top_p: None,
             system_prompt: None,
             tools: None,
+            native_tools: vec![],
+            thinking: None,
+            thinking_budget: None,
         };
 
         // Test the model
@@ -2012,6 +2019,9 @@ impl Mutation {
                 top_p: None,
                 system_prompt: Some("You are a helpful assistant.".to_string()),
                 tools: None,
+                native_tools: vec![],
+                thinking: None,
+                thinking_budget: None,
             };
             service
                 .invoke_model(invoke_request)
@@ -2485,12 +2495,32 @@ async fn stream_reply(
     let chat_id = chat.id.clone();
 
     let model_messages = preprocess_messages(convert_messages_to_model_format(&context_messages));
+
+    // OpenAI Responses models expose web_search / code_interpreter as
+    // provider-native tool blocks instead of local function tools (Node
+    // parity: the distinction is by protocol).
+    let use_responses = model.api_provider == "OPEN_AI"
+        && crate::services::openai_responses::uses_responses_api(&model.model_id);
+    let native_tools: Vec<String> = if use_responses {
+        chat.tools
+            .as_deref()
+            .and_then(|json| serde_json::from_str::<Vec<crate::models::ChatTool>>(json).ok())
+            .unwrap_or_default()
+            .into_iter()
+            .map(|t| t.r#type)
+            .filter(|t| t == "web_search" || t == "code_interpreter")
+            .collect()
+    } else {
+        Vec::new()
+    };
+
     let executable_tools = build_chat_tools(
         &mut conn,
         effective_config,
         chat.user_id.as_deref().unwrap_or_default(),
         chat.tools.as_deref(),
         mcp_tokens,
+        use_responses, // skip local web_search when native web_search is used
     )
     .await;
 
@@ -2502,6 +2532,9 @@ async fn stream_reply(
         top_p,
         system_prompt,
         tools: (!executable_tools.is_empty()).then_some(executable_tools),
+        native_tools,
+        thinking: Some(chat.thinking),
+        thinking_budget: chat.thinking_budget,
     };
 
     let accumulated_content = Arc::new(Mutex::new(String::new()));
@@ -2736,6 +2769,9 @@ async fn generate_rag_reply(
                 top_p: None,
                 system_prompt: Some(prompt.system_prompt),
                 tools: None,
+                native_tools: vec![],
+                thinking: None,
+                thinking_budget: None,
             })
             .await?;
 
@@ -2973,6 +3009,9 @@ async fn build_chat_tools(
     user_id: &str,
     tools_json: Option<&str>,
     mcp_tokens: Option<&[crate::models::McpAuthTokenInput]>,
+    // OpenAI Responses models serve web_search natively; skip the local
+    // Yandex web-search function tool to avoid duplication.
+    exclude_native_web_search: bool,
 ) -> Vec<crate::services::ai::ExecutableTool> {
     use crate::schema::mcp_servers;
     use crate::services::ai::{ExecutableTool, ToolBackend, ToolSpec};
@@ -2986,7 +3025,7 @@ async fn build_chat_tools(
 
     let mut result = Vec::new();
 
-    if chat_tools.iter().any(|t| t.r#type == "web_search") {
+    if !exclude_native_web_search && chat_tools.iter().any(|t| t.r#type == "web_search") {
         match crate::services::web_search::web_search_tool(config) {
             Some(tool) => result.push(tool),
             None => warn!("Web search tool requested but Yandex Search is not configured"),

--- a/api-rust/src/graphql/mutation.rs
+++ b/api-rust/src/graphql/mutation.rs
@@ -1233,7 +1233,6 @@ impl Mutation {
         let ai_message = prepare_regeneration_target(&mut conn, &chat.id, reused, &model, None)?;
         publish_message(pubsub, &chat.id, &ai_message, true).await;
 
-        let response_message = ai_message.clone();
         regenerate_reply(
             gql_ctx,
             user,
@@ -1246,8 +1245,12 @@ impl Mutation {
         )
         .await?;
 
+        // Node's editMessage returns the edited *user* message — the assistant
+        // reply reaches the client over the subscription. Returning the
+        // assistant target instead would make the client re-add it with the
+        // (pre-stream) empty content, wiping the just-streamed reply.
         Ok(EditMessageResponse {
-            message: Some(GqlMessage::from(response_message)),
+            message: Some(GqlMessage::from(updated)),
             error: None,
         })
     }
@@ -1319,7 +1322,7 @@ impl Mutation {
             prepare_regeneration_target(&mut conn, &chat.id, Some(original), &model, None)?;
         publish_message(pubsub, &chat.id, &ai_message, true).await;
 
-        let response_message = ai_message.clone();
+        let ai_message_id = ai_message.id.clone();
         regenerate_reply(
             gql_ctx,
             user,
@@ -1331,6 +1334,14 @@ impl Mutation {
             message_context.as_ref(),
         )
         .await?;
+
+        // Return the assistant message with its final streamed content
+        // (Node returns the mutated message). The pre-stream clone would
+        // carry empty content and blank the reply on the client.
+        let response_message = messages::table
+            .filter(messages::id.eq(&ai_message_id))
+            .first::<Message>(&mut conn)
+            .map_err(|e| AppError::Database(e.to_string()))?;
 
         Ok(SwitchModelResponse {
             message: Some(GqlMessage::from(response_message)),
@@ -1399,7 +1410,7 @@ impl Mutation {
             .map_err(|e| AppError::Database(e.to_string()))?;
         publish_message(pubsub, &chat.id, &ai_message, true).await;
 
-        let response_message = ai_message.clone();
+        let ai_message_id = ai_message.id.clone();
         regenerate_reply(
             gql_ctx,
             user,
@@ -1411,6 +1422,13 @@ impl Mutation {
             message_context.as_ref(),
         )
         .await?;
+
+        // Return the linked reply with its final streamed content (the
+        // pre-stream clone would be empty and blank the reply on the client).
+        let response_message = messages::table
+            .filter(messages::id.eq(&ai_message_id))
+            .first::<Message>(&mut conn)
+            .map_err(|e| AppError::Database(e.to_string()))?;
 
         Ok(CallOtherResponse {
             message: Some(GqlMessage::from(response_message)),

--- a/api-rust/src/graphql/mutation.rs
+++ b/api-rust/src/graphql/mutation.rs
@@ -903,6 +903,16 @@ impl Mutation {
             }
         }
 
+        // Inline chat-context files (PDF/text) sent with the message.
+        if let Some(files) = input.files.as_ref().filter(|f| !f.is_empty()) {
+            let effective_config = gql_ctx.config.with_user_settings(user.settings.as_ref());
+            if let Err(e) =
+                store_input_files(gql_ctx, &effective_config, &chat, &mut message, files).await
+            {
+                warn!("Failed to store input files: {:?}", e);
+            }
+        }
+
         diesel::update(
             chats::table
                 .filter(chats::id.eq(&input.chat_id))
@@ -2249,6 +2259,125 @@ async fn store_input_audio(
     Ok(())
 }
 
+/// Store a user turn's inline chat-context files to S3, record a `chat_files`
+/// row per file (type inline_document) and reference them from the message
+/// (jsonContent `file` blocks + markdown links) — Node's saveFileFromBase64
+/// + ModelMessageContentFile shape.
+async fn store_input_files(
+    gql_ctx: &GraphQLContext,
+    effective_config: &crate::config::AppConfig,
+    chat: &Chat,
+    message: &mut Message,
+    files: &[crate::models::FileInput],
+) -> Result<(), AppError> {
+    use base64::Engine;
+    let mut conn = gql_ctx
+        .db_pool
+        .get()
+        .map_err(|e| AppError::Database(e.to_string()))?;
+    let mut s3 = S3Service::new(effective_config.clone());
+
+    // Preserve any existing jsonContent blocks (e.g. an audio block).
+    let mut blocks: Vec<serde_json::Value> = message
+        .json_content
+        .as_deref()
+        .and_then(|s| serde_json::from_str(s).ok())
+        .unwrap_or_default();
+
+    for (index, file) in files.iter().enumerate() {
+        // bytesBase64 may be a data URL or raw base64.
+        let (mime, b64) = if file.bytes_base64.starts_with("data:") {
+            let (m, d) = split_audio_data_url(&file.bytes_base64);
+            (m.to_string(), d.to_string())
+        } else {
+            (file.mime_type.clone(), file.bytes_base64.clone())
+        };
+        let bytes = match base64::engine::general_purpose::STANDARD.decode(b64.trim()) {
+            Ok(bytes) => bytes,
+            Err(e) => {
+                warn!("Invalid file base64 for {}: {}", file.file_name, e);
+                continue;
+            }
+        };
+        let ext = file_extension_for_mime(&mime);
+        let s3_key = format!(
+            "{}/{}/{}-file-{}.{}",
+            chat.id,
+            message.id,
+            index,
+            uuid::Uuid::new_v4(),
+            ext
+        );
+        if let Err(e) = s3.upload_file(&s3_key, bytes, &mime).await {
+            warn!("Failed to store input file {}: {:?}", file.file_name, e);
+            continue;
+        }
+        let chat_file = crate::models::ChatFile::new_inline_document(
+            chat.id.clone(),
+            Some(message.id.clone()),
+            s3_key.clone(),
+            file.file_name.clone(),
+            mime.clone(),
+        );
+        let _ = diesel::insert_into(chat_files::table)
+            .values(&chat_file)
+            .execute(&mut conn);
+
+        blocks.push(serde_json::json!({
+            "contentType": "file",
+            "fileName": s3_key,
+            "mimeType": mime,
+            "uploadFileName": file.file_name,
+            "size": file.size,
+        }));
+        let link = format!(
+            "[{}]({})",
+            file.file_name,
+            crate::models::chat_file::file_url(&s3_key)
+        );
+        message.content = if message.content.is_empty() {
+            link
+        } else {
+            format!("{}\n\n{}", message.content, link)
+        };
+    }
+
+    message.json_content = Some(serde_json::to_string(&blocks).unwrap_or_default());
+    let updated: Message = diesel::update(messages::table.filter(messages::id.eq(&message.id)))
+        .set((
+            messages::content.eq(&message.content),
+            messages::json_content.eq(&message.json_content),
+            messages::updated_at.eq(Utc::now().naive_utc()),
+        ))
+        .get_result(&mut conn)
+        .map_err(|e| AppError::Database(e.to_string()))?;
+    *message = updated;
+    Ok(())
+}
+
+/// Storage extension for an inline-file mime (Node's FILE_MIME_EXTENSIONS;
+/// unknown mimes fall back to `bin`).
+fn file_extension_for_mime(mime: &str) -> &'static str {
+    match mime
+        .split(';')
+        .next()
+        .unwrap_or("")
+        .trim()
+        .to_lowercase()
+        .as_str()
+    {
+        "application/pdf" => "pdf",
+        "text/plain" => "txt",
+        "text/markdown" | "text/x-markdown" => "md",
+        "text/csv" | "application/csv" => "csv",
+        "text/html" => "html",
+        "application/json" => "json",
+        "application/xml" | "text/xml" => "xml",
+        "application/x-yaml" | "text/yaml" => "yaml",
+        _ => "bin",
+    }
+}
+
 /// Map an audio mime type to the OpenAI `input_audio` format (wav/mp3);
 /// chat.completions accepts only those two (Node parity).
 fn audio_input_format(mime: &str) -> String {
@@ -2776,7 +2905,10 @@ async fn stream_reply(
     let pubsub = get_global_pubsub();
     let chat_id = chat.id.clone();
 
-    let model_messages = preprocess_messages(convert_messages_to_model_format(&context_messages));
+    let mut model_messages =
+        preprocess_messages(convert_messages_to_model_format(&context_messages));
+    // Preload inline chat-context file content from S3 into the request.
+    preload_file_content(&mut model_messages, effective_config, model.image_input).await;
 
     // OpenAI Responses models expose web_search / code_interpreter as
     // provider-native tool blocks instead of local function tools (Node
@@ -3504,8 +3636,87 @@ fn convert_messages_to_model_format(
             tool_calls: None,
             tool_call_id: None,
             audio: None,
+            files: parse_file_blocks(msg.json_content.as_deref()),
         })
         .collect()
+}
+
+/// Extract inline-file content blocks (`contentType: "file"`) from a stored
+/// message's jsonContent into ModelFile stubs (content preloaded later).
+fn parse_file_blocks(json_content: Option<&str>) -> Vec<crate::services::ai::ModelFile> {
+    let Some(blocks) =
+        json_content.and_then(|s| serde_json::from_str::<Vec<serde_json::Value>>(s).ok())
+    else {
+        return Vec::new();
+    };
+    blocks
+        .iter()
+        .filter(|b| b.get("contentType").and_then(|c| c.as_str()) == Some("file"))
+        .filter_map(|b| {
+            let s3_key = b.get("fileName").and_then(|f| f.as_str())?.to_string();
+            let mime_type = b
+                .get("mimeType")
+                .and_then(|m| m.as_str())
+                .unwrap_or("application/octet-stream")
+                .to_string();
+            let name = b
+                .get("uploadFileName")
+                .and_then(|u| u.as_str())
+                .map(String::from)
+                .or_else(|| s3_key.rsplit('/').next().map(String::from))
+                .unwrap_or_else(|| "document".to_string());
+            Some(crate::services::ai::ModelFile {
+                s3_key,
+                name,
+                mime_type,
+                text: None,
+                base64: None,
+            })
+        })
+        .collect()
+}
+
+/// Preload inline-file content from S3 into the model messages: textual
+/// files become UTF-8 text, other files (PDF) become base64 — but binary
+/// files are only loaded for image-capable models (PDF understanding rides
+/// on vision support in the completions API; Node parity).
+async fn preload_file_content(
+    messages: &mut [crate::services::ai::ModelMessage],
+    config: &crate::config::AppConfig,
+    image_capable: bool,
+) {
+    use base64::Engine;
+    if messages.iter().all(|m| m.files.is_empty()) {
+        return;
+    }
+    let mut s3 = S3Service::new(config.clone());
+    for message in messages.iter_mut() {
+        for file in message.files.iter_mut() {
+            let textual = crate::services::ai::is_textual_mime(&file.mime_type);
+            if !textual && !image_capable {
+                warn!(
+                    "Model does not support file input, skipping {}",
+                    file.s3_key
+                );
+                continue;
+            }
+            match s3.get_file(&file.s3_key).await {
+                Ok((bytes, _)) => {
+                    if textual {
+                        file.text = Some(String::from_utf8_lossy(&bytes).into_owned());
+                    } else {
+                        file.base64 =
+                            Some(base64::engine::general_purpose::STANDARD.encode(&bytes));
+                    }
+                }
+                Err(e) => warn!("Failed to load inline file {}: {:?}", file.s3_key, e),
+            }
+        }
+        // Drop files that could not be loaded (unsupported / missing).
+        message
+            .files
+            .retain(|f| f.text.is_some() || f.base64.is_some());
+    }
 }
 
 /// Preprocess messages: sort by timestamp and join consecutive messages from the same role

--- a/api-rust/src/graphql/mutation.rs
+++ b/api-rust/src/graphql/mutation.rs
@@ -1232,23 +1232,22 @@ impl Mutation {
         // Reuse or create the assistant target message
         let ai_message = prepare_regeneration_target(&mut conn, &chat.id, reused, &model, None)?;
         publish_message(pubsub, &chat.id, &ai_message, true).await;
+        drop(conn);
 
-        regenerate_reply(
-            gql_ctx,
-            user,
-            &chat,
-            &model,
-            &updated,
+        // Stream the reply in the background and return right away (Node
+        // parity). The reply reaches the client over the subscription.
+        spawn_regenerate(
+            gql_ctx.clone(),
+            user.clone(),
+            chat,
+            model,
+            updated.clone(),
             ai_message,
             document_ids,
-            message_context.as_ref(),
-        )
-        .await?;
+            message_context,
+        );
 
-        // Node's editMessage returns the edited *user* message — the assistant
-        // reply reaches the client over the subscription. Returning the
-        // assistant target instead would make the client re-add it with the
-        // (pre-stream) empty content, wiping the just-streamed reply.
+        // editMessage returns the edited *user* message (Node parity).
         Ok(EditMessageResponse {
             message: Some(GqlMessage::from(updated)),
             error: None,
@@ -1321,27 +1320,21 @@ impl Mutation {
         let ai_message =
             prepare_regeneration_target(&mut conn, &chat.id, Some(original), &model, None)?;
         publish_message(pubsub, &chat.id, &ai_message, true).await;
+        drop(conn);
 
-        let ai_message_id = ai_message.id.clone();
-        regenerate_reply(
-            gql_ctx,
-            user,
-            &chat,
-            &model,
-            &trigger,
+        // Node returns the reset (empty) message and fire-and-forgets the
+        // stream; the reply fills in over the subscription.
+        let response_message = ai_message.clone();
+        spawn_regenerate(
+            gql_ctx.clone(),
+            user.clone(),
+            chat,
+            model,
+            trigger,
             ai_message,
             document_ids,
-            message_context.as_ref(),
-        )
-        .await?;
-
-        // Return the assistant message with its final streamed content
-        // (Node returns the mutated message). The pre-stream clone would
-        // carry empty content and blank the reply on the client.
-        let response_message = messages::table
-            .filter(messages::id.eq(&ai_message_id))
-            .first::<Message>(&mut conn)
-            .map_err(|e| AppError::Database(e.to_string()))?;
+            message_context,
+        );
 
         Ok(SwitchModelResponse {
             message: Some(GqlMessage::from(response_message)),
@@ -1409,26 +1402,21 @@ impl Mutation {
             .get_result::<Message>(&mut conn)
             .map_err(|e| AppError::Database(e.to_string()))?;
         publish_message(pubsub, &chat.id, &ai_message, true).await;
+        drop(conn);
 
-        let ai_message_id = ai_message.id.clone();
-        regenerate_reply(
-            gql_ctx,
-            user,
-            &chat,
-            &model,
-            &original,
+        // Node returns the empty linked reply and fire-and-forgets the stream;
+        // the alternate reply fills in over the subscription.
+        let response_message = ai_message.clone();
+        spawn_regenerate(
+            gql_ctx.clone(),
+            user.clone(),
+            chat,
+            model,
+            original,
             ai_message,
             None,
-            message_context.as_ref(),
-        )
-        .await?;
-
-        // Return the linked reply with its final streamed content (the
-        // pre-stream clone would be empty and blank the reply on the client).
-        let response_message = messages::table
-            .filter(messages::id.eq(&ai_message_id))
-            .first::<Message>(&mut conn)
-            .map_err(|e| AppError::Database(e.to_string()))?;
+            message_context,
+        );
 
         Ok(CallOtherResponse {
             message: Some(GqlMessage::from(response_message)),
@@ -2765,6 +2753,93 @@ async fn publish_message(
     };
     if let Err(e) = pubsub.publish_to_chat(chat_id, pub_message).await {
         warn!("Failed to publish message to subscribers: {:?}", e);
+    }
+}
+
+/// Run a regeneration stream in the background and return immediately.
+///
+/// Node fire-and-forgets `publishAssistantMessage` (streamChatCompletion is
+/// not awaited), so the editMessage/switchModel/callOther mutations resolve
+/// before the reply streams. That ordering matters on the client: the
+/// editMessage handler calls `removeMessages` (a full list reset) in
+/// `onCompleted`; if the mutation only resolved *after* the stream finished,
+/// that reset would run last and revert the just-streamed reply to its empty
+/// placeholder (message shows a spinner forever). Spawning the stream here
+/// reproduces Node's ordering — the placeholder is already published, the
+/// mutation returns, and the streamed tokens arrive over the subscription.
+#[allow(clippy::too_many_arguments)]
+fn spawn_regenerate(
+    gql_ctx: GraphQLContext,
+    user: User,
+    chat: Chat,
+    model: Model,
+    trigger: Message,
+    ai_message: Message,
+    document_ids: Option<Vec<String>>,
+    message_context: Option<crate::models::MessageContextInput>,
+) {
+    let ai_message_id = ai_message.id.clone();
+    let chat_id = chat.id.clone();
+    tokio::spawn(async move {
+        if let Err(e) = regenerate_reply(
+            &gql_ctx,
+            &user,
+            &chat,
+            &model,
+            &trigger,
+            ai_message,
+            document_ids,
+            message_context.as_ref(),
+        )
+        .await
+        {
+            warn!(
+                "Regeneration failed for message {}: {:?}",
+                ai_message_id, e
+            );
+            publish_regeneration_error(&gql_ctx, &chat_id, &ai_message_id, &e).await;
+        }
+    });
+}
+
+/// Turn a still-empty regeneration target into an error message when the
+/// background stream fails before its own `on_error` published one (e.g.
+/// provider setup errors), so the client isn't left with a spinner.
+async fn publish_regeneration_error(
+    gql_ctx: &GraphQLContext,
+    chat_id: &str,
+    message_id: &str,
+    err: &AppError,
+) {
+    let Ok(mut conn) = gql_ctx.db_pool.get() else {
+        return;
+    };
+    // Skip if the stream's on_error callback already reported the failure.
+    if let Ok(existing) = messages::table
+        .filter(messages::id.eq(message_id))
+        .first::<Message>(&mut conn)
+    {
+        if existing.role == String::from(MessageRole::Error) {
+            return;
+        }
+    }
+    let content = format!("Model inference error: {:?}", err);
+    if diesel::update(messages::table.filter(messages::id.eq(message_id)))
+        .set((
+            messages::content.eq(&content),
+            messages::role.eq(String::from(MessageRole::Error)),
+            messages::updated_at.eq(Utc::now().naive_utc()),
+        ))
+        .execute(&mut conn)
+        .is_err()
+    {
+        return;
+    }
+    if let Ok(updated) = messages::table
+        .filter(messages::id.eq(message_id))
+        .first::<Message>(&mut conn)
+    {
+        publish_message(get_global_pubsub(), chat_id, &updated, false).await;
     }
 }
 

--- a/api-rust/src/graphql/mutation.rs
+++ b/api-rust/src/graphql/mutation.rs
@@ -2793,10 +2793,7 @@ fn spawn_regenerate(
         )
         .await
         {
-            warn!(
-                "Regeneration failed for message {}: {:?}",
-                ai_message_id, e
-            );
+            warn!("Regeneration failed for message {}: {:?}", ai_message_id, e);
             publish_regeneration_error(&gql_ctx, &chat_id, &ai_message_id, &e).await;
         }
     });

--- a/api-rust/src/graphql/query.rs
+++ b/api-rust/src/graphql/query.rs
@@ -565,8 +565,11 @@ impl Query {
 
         let limit = input.limit.unwrap_or(20);
         let offset = input.offset.unwrap_or(0);
+        // Main thread only — alternate replies (callOther) are attached
+        // below as linkedMessages (Node parity)
         let messages_result: Vec<Message> = messages::table
             .filter(messages::chat_id.eq(&input.chat_id))
+            .filter(messages::linked_to_message_id.is_null())
             .order(messages::created_at.asc())
             .limit(i64::from(limit))
             .offset(i64::from(offset))
@@ -575,12 +578,38 @@ impl Query {
 
         let total: i64 = messages::table
             .filter(messages::chat_id.eq(&input.chat_id))
+            .filter(messages::linked_to_message_id.is_null())
             .count()
             .get_result(&mut conn)
             .map_err(|e| AppError::Database(e.to_string()))?;
 
+        let ids: Vec<String> = messages_result.iter().map(|m| m.id.clone()).collect();
+        let linked: Vec<Message> = messages::table
+            .filter(messages::linked_to_message_id.eq_any(&ids))
+            .order(messages::created_at.asc())
+            .load(&mut conn)
+            .map_err(|e| AppError::Database(e.to_string()))?;
+        let mut linked_by_parent: std::collections::HashMap<String, Vec<GqlMessage>> =
+            std::collections::HashMap::new();
+        for message in linked {
+            if let Some(parent) = message.linked_to_message_id.clone() {
+                linked_by_parent
+                    .entry(parent)
+                    .or_default()
+                    .push(GqlMessage::from(message));
+            }
+        }
+        let gql_messages: Vec<GqlMessage> = messages_result
+            .into_iter()
+            .map(|m| {
+                let mut gql = GqlMessage::from(m);
+                gql.linked_messages = linked_by_parent.remove(&gql.id);
+                gql
+            })
+            .collect();
+
         Ok(GqlMessagesList {
-            messages: messages_result.into_iter().map(GqlMessage::from).collect(),
+            messages: gql_messages,
             chat: chat.map(GqlChat::from),
             total: Some(total as i32),
             has_more: (offset + limit) < total as i32,

--- a/api-rust/src/graphql/query.rs
+++ b/api-rust/src/graphql/query.rs
@@ -707,6 +707,94 @@ impl Query {
         Ok(gql_models)
     }
 
+    /// Global search over the user's chats, messages and documents
+    /// (Node's search resolver; LIKE-based — api-rust has no FTS tables)
+    async fn search(
+        &self,
+        ctx: &Context<'_>,
+        input: crate::models::SearchInput,
+    ) -> Result<crate::models::SearchResults> {
+        use crate::models::search::snippet;
+        use crate::schema::documents;
+
+        let gql_ctx = ctx.data::<GraphQLContext>()?;
+        let user = gql_ctx.require_user()?;
+        let mut conn = gql_ctx
+            .db_pool
+            .get()
+            .map_err(|e| AppError::Database(e.to_string()))?;
+
+        let query = input.query.trim().to_string();
+        let limit = input.limit.unwrap_or(10).clamp(1, 50) as i64;
+        if query.chars().count() < 2 {
+            return Ok(crate::models::SearchResults {
+                chat_results: vec![],
+                message_results: vec![],
+                document_results: vec![],
+            });
+        }
+        let pattern = format!("%{}%", query.replace('%', "\\%").replace('_', "\\_"));
+
+        let chat_rows: Vec<Chat> = chats::table
+            .filter(chats::user_id.eq(&user.id))
+            .filter(chats::title.like(&pattern))
+            .order(chats::updated_at.desc())
+            .limit(limit)
+            .load(&mut conn)
+            .map_err(|e| AppError::Database(e.to_string()))?;
+        let chat_results = chat_rows
+            .into_iter()
+            .map(|c| crate::models::SearchChatResult {
+                chat_id: c.id.into(),
+                title: c.title,
+            })
+            .collect();
+
+        let message_rows: Vec<(Message, Chat)> = messages::table
+            .inner_join(chats::table)
+            .filter(chats::user_id.eq(&user.id))
+            .filter(messages::content.like(&pattern))
+            .order(messages::created_at.desc())
+            .limit(limit)
+            .load(&mut conn)
+            .map_err(|e| AppError::Database(e.to_string()))?;
+        let message_results = message_rows
+            .into_iter()
+            .map(|(m, c)| crate::models::SearchMessageResult {
+                message_id: m.id.into(),
+                chat_id: m.chat_id,
+                chat_title: c.title,
+                snippet: snippet(&m.content),
+            })
+            .collect();
+
+        let document_rows: Vec<crate::models::Document> = documents::table
+            .filter(documents::owner_id.eq(&user.id))
+            .filter(
+                documents::file_name
+                    .like(&pattern)
+                    .or(documents::summary.like(&pattern)),
+            )
+            .order(documents::updated_at.desc())
+            .limit(limit)
+            .load(&mut conn)
+            .map_err(|e| AppError::Database(e.to_string()))?;
+        let document_results = document_rows
+            .into_iter()
+            .map(|d| crate::models::SearchDocumentResult {
+                document_id: d.id.into(),
+                file_name: d.file_name,
+                snippet: d.summary.as_deref().map(snippet),
+            })
+            .collect();
+
+        Ok(crate::models::SearchResults {
+            chat_results,
+            message_results,
+            document_results,
+        })
+    }
+
     /// Get costs information
     async fn get_costs(&self, ctx: &Context<'_>, input: GetCostsInput) -> Result<GqlCostsInfo> {
         let gql_ctx = ctx.data::<GraphQLContext>()?;

--- a/api-rust/src/main.rs
+++ b/api-rust/src/main.rs
@@ -140,8 +140,13 @@ async fn rocket() -> Rocket<Build> {
         });
     }
 
+    // Raise the GraphQL body limit (async-graphql-rocket defaults to 128 KiB,
+    // which rejects inline file/image uploads with a 400). Mirrors Node's
+    // express.json({ limit: MAX_INPUT_JSON }).
+    use rocket::data::{Limits, ToByteUnit};
     let rocket_config = Config {
         port: config.port,
+        limits: Limits::default().limit("graphql", config.max_input_json_bytes.bytes()),
         ..Config::debug_default()
     };
 

--- a/api-rust/src/models/chat.rs
+++ b/api-rust/src/models/chat.rs
@@ -58,6 +58,9 @@ pub struct Chat {
     pub created_at: NaiveDateTime,
     pub updated_at: NaiveDateTime,
     pub folder_id: Option<String>,
+    pub voice: Option<String>,
+    pub thinking: bool,
+    pub thinking_budget: Option<i32>,
 }
 
 // Custom struct for the joined chat query result
@@ -97,6 +100,12 @@ pub struct ChatWithStats {
     pub is_pinned: bool,
     #[diesel(sql_type = Nullable<Text>)]
     pub folder_id: Option<String>,
+    #[diesel(sql_type = Nullable<Text>)]
+    pub voice: Option<String>,
+    #[diesel(sql_type = Bool)]
+    pub thinking: bool,
+    #[diesel(sql_type = Nullable<Integer>)]
+    pub thinking_budget: Option<i32>,
     #[diesel(sql_type = Timestamp)]
     pub created_at: chrono::NaiveDateTime,
     #[diesel(sql_type = Timestamp)]
@@ -119,6 +128,9 @@ pub struct NewChat {
     pub is_pristine: bool,
     pub is_pinned: bool,
     pub folder_id: Option<String>,
+    pub voice: Option<String>,
+    pub thinking: bool,
+    pub thinking_budget: Option<i32>,
     pub created_at: NaiveDateTime,
     pub updated_at: NaiveDateTime,
 }
@@ -146,6 +158,9 @@ impl NewChat {
             is_pristine: true,
             is_pinned: false,
             folder_id: None,
+            voice: None,
+            thinking: false,
+            thinking_budget: None,
             created_at: now,
             updated_at: now,
         }
@@ -260,12 +275,16 @@ pub struct GqlChat {
     pub chat_documents: Option<Vec<GqlChatDocument>>,
 }
 
+#[allow(clippy::too_many_arguments)]
 fn chat_settings(
     system_prompt: &Option<String>,
     temperature: Option<f32>,
     max_tokens: Option<i32>,
     top_p: Option<f32>,
     images_count: Option<i32>,
+    voice: &Option<String>,
+    thinking: bool,
+    thinking_budget: Option<i32>,
 ) -> ChatSettings {
     ChatSettings {
         temperature,
@@ -273,6 +292,9 @@ fn chat_settings(
         top_p,
         images_count,
         system_prompt: system_prompt.clone(),
+        voice: voice.clone(),
+        thinking: Some(thinking),
+        thinking_budget,
         ..ChatSettings::default()
     }
 }
@@ -289,6 +311,9 @@ impl From<Chat> for GqlChat {
             chat.max_tokens,
             chat.top_p,
             chat.images_count,
+            &chat.voice,
+            chat.thinking,
+            chat.thinking_budget,
         ));
         Self {
             id: chat.id,
@@ -329,6 +354,9 @@ impl From<ChatWithStats> for GqlChat {
             chat.max_tokens,
             chat.top_p,
             chat.images_count,
+            &chat.voice,
+            chat.thinking,
+            chat.thinking_budget,
         ));
         Self {
             id: chat.id,

--- a/api-rust/src/models/chat_file.rs
+++ b/api-rust/src/models/chat_file.rs
@@ -77,6 +77,31 @@ impl ChatFile {
             updated_at: now,
         }
     }
+
+    /// Inline chat-context file (PDF/text attached to a message).
+    /// `upload_file` keeps the original client filename (Node parity).
+    pub fn new_inline_document(
+        chat_id: String,
+        message_id: Option<String>,
+        file_name: String,
+        upload_file: String,
+        mime: String,
+    ) -> Self {
+        let now = Utc::now().naive_utc();
+        Self {
+            id: Uuid::new_v4().to_string(),
+            chat_id,
+            message_id,
+            type_: CHAT_FILE_TYPE_INLINE_DOCUMENT.to_string(),
+            file_name: Some(file_name),
+            mime: Some(mime),
+            upload_file: Some(upload_file),
+            predominant_color: None,
+            exif: None,
+            created_at: now,
+            updated_at: now,
+        }
+    }
 }
 
 pub fn file_url(file_name: &str) -> String {

--- a/api-rust/src/models/chat_file.rs
+++ b/api-rust/src/models/chat_file.rs
@@ -14,6 +14,7 @@ use crate::schema::chat_files;
 
 pub const CHAT_FILE_TYPE_IMAGE: &str = "image";
 pub const CHAT_FILE_TYPE_INLINE_DOCUMENT: &str = "inline_document";
+pub const CHAT_FILE_TYPE_AUDIO: &str = "audio";
 
 #[derive(Debug, Clone, Serialize, Deserialize, Queryable, Insertable)]
 #[diesel(table_name = chat_files)]
@@ -45,6 +46,28 @@ impl ChatFile {
             chat_id,
             message_id,
             type_: CHAT_FILE_TYPE_IMAGE.to_string(),
+            file_name: Some(file_name),
+            mime: Some(mime),
+            upload_file: None,
+            predominant_color: None,
+            exif: None,
+            created_at: now,
+            updated_at: now,
+        }
+    }
+
+    pub fn new_audio(
+        chat_id: String,
+        message_id: Option<String>,
+        file_name: String,
+        mime: String,
+    ) -> Self {
+        let now = Utc::now().naive_utc();
+        Self {
+            id: Uuid::new_v4().to_string(),
+            chat_id,
+            message_id,
+            type_: CHAT_FILE_TYPE_AUDIO.to_string(),
             file_name: Some(file_name),
             mime: Some(mime),
             upload_file: None,

--- a/api-rust/src/models/mcp_server.rs
+++ b/api-rust/src/models/mcp_server.rs
@@ -165,9 +165,8 @@ pub struct GqlMcpToolTestResponse {
     pub error: Option<String>,
 }
 
-/// Chat folder (sidebar tree). Folders are not ported yet — the type exists
-/// so the client's `getFolders` bootstrap query validates; the list is
-/// always empty.
+/// Chat folder (sidebar tree) — the GraphQL projection of a `chat_folders`
+/// row.
 #[derive(Debug, Serialize, Deserialize, SimpleObject)]
 #[graphql(name = "Folder")]
 pub struct GqlFolder {

--- a/api-rust/src/models/message.rs
+++ b/api-rust/src/models/message.rs
@@ -356,10 +356,45 @@ impl From<String> for MessageType {
     }
 }
 
+impl Message {
+    /// Deserialize the stored metadata JSON (None on absence/corruption).
+    pub fn parsed_metadata(&self) -> Option<MessageMetadata> {
+        self.metadata
+            .as_deref()
+            .and_then(|m| serde_json::from_str(m).ok())
+    }
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize, SimpleObject)]
 pub struct EditMessageResponse {
     pub message: Option<GqlMessage>,
     pub error: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, SimpleObject)]
+pub struct SwitchModelResponse {
+    pub message: Option<GqlMessage>,
+    pub error: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, SimpleObject)]
+pub struct CallOtherResponse {
+    pub message: Option<GqlMessage>,
+    pub error: Option<String>,
+}
+
+#[derive(Debug, InputObject)]
+#[graphql(name = "StopMessageGenerationInput")]
+pub struct StopMessageGenerationInput {
+    pub request_id: String,
+    pub message_id: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, SimpleObject)]
+pub struct StopMessageGenerationResponse {
+    pub error: Option<String>,
+    pub request_id: Option<String>,
+    pub message_id: Option<String>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, SimpleObject)]

--- a/api-rust/src/models/message.rs
+++ b/api-rust/src/models/message.rs
@@ -150,6 +150,13 @@ pub struct CreateMessageInput {
 }
 
 #[derive(Debug, Serialize, Deserialize, InputObject)]
+pub struct AddChatMessageInput {
+    pub chat_id: String,
+    pub content: String,
+    pub role: String,
+}
+
+#[derive(Debug, Serialize, Deserialize, InputObject)]
 pub struct ImageInput {
     pub bytes_base64: String,
     pub file_name: String,

--- a/api-rust/src/models/message.rs
+++ b/api-rust/src/models/message.rs
@@ -137,15 +137,13 @@ pub struct CreateMessageInput {
     pub max_tokens: Option<i32>,
     pub top_p: Option<f32>,
     pub images: Option<Vec<ImageInput>>,
-    /// Voice recording input — accepted for schema compatibility;
-    /// audio models are not ported yet.
+    /// Voice recording input for audio-input models (gpt-4o-audio, …).
     pub audio: Option<AudioInput>,
-    /// Inline chat-context documents — accepted for schema compatibility;
-    /// file content blocks are not ported yet.
+    /// Inline chat-context files (PDF/text) sent to the model as file
+    /// content blocks.
     pub files: Option<Vec<FileInput>>,
     pub document_ids: Option<Vec<String>>,
-    /// MCP auth tokens — accepted for schema compatibility; MCP is not
-    /// ported yet.
+    /// Per-request MCP auth tokens (OAuth bearer per server).
     pub mcp_tokens: Option<Vec<McpAuthTokenInput>>,
 }
 
@@ -320,8 +318,7 @@ pub struct GqlDeleteMessageResponse {
 }
 
 /// Per-request context passed by the client alongside message mutations
-/// (MCP auth tokens, context-limit reset). Accepted for schema
-/// compatibility; MCP is not ported yet.
+/// (MCP auth tokens, context-limit reset).
 #[derive(Debug, Clone, Serialize, Deserialize, InputObject)]
 #[graphql(name = "MessageContext")]
 pub struct MessageContextInput {

--- a/api-rust/src/models/message.rs
+++ b/api-rust/src/models/message.rs
@@ -356,9 +356,8 @@ impl From<MessageType> for String {
 impl From<String> for MessageType {
     fn from(msg_type: String) -> Self {
         match msg_type.as_str() {
-            "message" => MessageType::Message,
             "system" => MessageType::System,
-            &_ => todo!(),
+            _ => MessageType::Message,
         }
     }
 }

--- a/api-rust/src/models/mod.rs
+++ b/api-rust/src/models/mod.rs
@@ -5,6 +5,7 @@ pub mod folder;
 pub mod mcp_server;
 pub mod message;
 pub mod model;
+pub mod search;
 pub mod user;
 
 pub use chat::*;
@@ -14,4 +15,5 @@ pub use folder::*;
 pub use mcp_server::*;
 pub use message::*;
 pub use model::*;
+pub use search::*;
 pub use user::*;

--- a/api-rust/src/models/search.rs
+++ b/api-rust/src/models/search.rs
@@ -1,0 +1,59 @@
+//! Global search result types (Node's SearchResults shapes).
+
+use async_graphql::SimpleObject;
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, Serialize, Deserialize, SimpleObject)]
+#[graphql(name = "SearchChatResult")]
+#[serde(rename_all = "camelCase")]
+pub struct SearchChatResult {
+    pub chat_id: async_graphql::ID,
+    pub title: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, SimpleObject)]
+#[graphql(name = "SearchMessageResult")]
+#[serde(rename_all = "camelCase")]
+pub struct SearchMessageResult {
+    pub message_id: async_graphql::ID,
+    pub chat_id: String,
+    pub chat_title: String,
+    pub snippet: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, SimpleObject)]
+#[graphql(name = "SearchDocumentResult")]
+#[serde(rename_all = "camelCase")]
+pub struct SearchDocumentResult {
+    pub document_id: async_graphql::ID,
+    pub file_name: String,
+    pub snippet: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, SimpleObject)]
+#[graphql(name = "SearchResults")]
+#[serde(rename_all = "camelCase")]
+pub struct SearchResults {
+    pub chat_results: Vec<SearchChatResult>,
+    pub message_results: Vec<SearchMessageResult>,
+    pub document_results: Vec<SearchDocumentResult>,
+}
+
+#[derive(Debug, async_graphql::InputObject)]
+#[graphql(name = "SearchInput")]
+pub struct SearchInput {
+    pub query: String,
+    pub limit: Option<i32>,
+}
+
+/// Truncate a snippet to 200 chars (Node parity).
+pub fn snippet(text: &str) -> String {
+    const MAX: usize = 200;
+    if text.chars().count() <= MAX {
+        text.to_string()
+    } else {
+        let mut s: String = text.chars().take(MAX).collect();
+        s.push('…');
+        s
+    }
+}

--- a/api-rust/src/models/user.rs
+++ b/api-rust/src/models/user.rs
@@ -255,6 +255,26 @@ impl NewUser {
 }
 
 #[derive(Debug, Serialize, Deserialize, InputObject)]
+pub struct ForgotPasswordInput {
+    pub email: String,
+    pub language: Option<String>,
+    pub recaptcha_token: Option<String>,
+}
+
+#[derive(Debug, Serialize, Deserialize, InputObject)]
+pub struct ResetPasswordInput {
+    pub token: String,
+    pub new_password: String,
+}
+
+#[derive(Debug, Serialize, Deserialize, async_graphql::SimpleObject)]
+#[graphql(name = "ForgotPasswordResponse")]
+pub struct ForgotPasswordResponse {
+    pub success: bool,
+    pub error: Option<String>,
+}
+
+#[derive(Debug, Serialize, Deserialize, InputObject)]
 pub struct RegisterInput {
     pub email: String,
     pub password: String,

--- a/api-rust/src/schema.rs
+++ b/api-rust/src/schema.rs
@@ -60,6 +60,10 @@ diesel::table! {
         updated_at -> Timestamp,
         // added by ALTER TABLE (2026-07-22 chat_folders migration) — physically last
         folder_id -> Nullable<Text>,
+        // added by ALTER TABLE (2026-07-24 chat_voice_thinking migration)
+        voice -> Nullable<Text>,
+        thinking -> Bool,
+        thinking_budget -> Nullable<Integer>,
     }
 }
 

--- a/api-rust/src/services/ai.rs
+++ b/api-rust/src/services/ai.rs
@@ -88,6 +88,38 @@ pub struct ModelAudio {
     pub format: String,
 }
 
+/// An inline chat-context file attached to a user turn (PDF/text),
+/// serialized as a provider file block. Content is preloaded from S3
+/// before the (synchronous) request body is built: textual files get
+/// `text`, binary files (PDF) get `base64`.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ModelFile {
+    /// S3 key of the stored file (used to preload content; not serialized
+    /// into the request).
+    #[serde(skip)]
+    pub s3_key: String,
+    /// Original upload filename, passed to the model as the document name.
+    pub name: String,
+    pub mime_type: String,
+    /// Preloaded UTF-8 content for textual files.
+    #[serde(default)]
+    pub text: Option<String>,
+    /// Preloaded base64 content for binary files (PDF).
+    #[serde(default)]
+    pub base64: Option<String>,
+}
+
+/// True for mime types inlined as plain text rather than a binary block
+/// (Node's isTextualMime).
+pub fn is_textual_mime(mime: &str) -> bool {
+    let m = mime.split(';').next().unwrap_or("").trim().to_lowercase();
+    m.starts_with("text/")
+        || matches!(
+            m.as_str(),
+            "application/json" | "application/xml" | "application/x-yaml"
+        )
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ModelMessage {
     pub role: MessageRole,
@@ -103,6 +135,9 @@ pub struct ModelMessage {
     /// Voice recording on a user turn (audio-input models).
     #[serde(default)]
     pub audio: Option<ModelAudio>,
+    /// Inline chat-context files on a user turn (content preloaded from S3).
+    #[serde(default)]
+    pub files: Vec<ModelFile>,
 }
 
 impl ModelMessage {
@@ -114,6 +149,7 @@ impl ModelMessage {
             tool_calls: None,
             tool_call_id: None,
             audio: None,
+            files: Vec::new(),
         }
     }
 }

--- a/api-rust/src/services/ai.rs
+++ b/api-rust/src/services/ai.rs
@@ -80,6 +80,14 @@ pub enum MessageRole {
     Tool,
 }
 
+/// A voice recording attached to a user turn (base64 + `wav`/`mp3`),
+/// serialized as an OpenAI `input_audio` content block.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ModelAudio {
+    pub data_base64: String,
+    pub format: String,
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ModelMessage {
     pub role: MessageRole,
@@ -92,6 +100,9 @@ pub struct ModelMessage {
     /// Set on tool-result turns (role = Tool).
     #[serde(default)]
     pub tool_call_id: Option<String>,
+    /// Voice recording on a user turn (audio-input models).
+    #[serde(default)]
+    pub audio: Option<ModelAudio>,
 }
 
 impl ModelMessage {
@@ -102,6 +113,7 @@ impl ModelMessage {
             timestamp: None,
             tool_calls: None,
             tool_call_id: None,
+            audio: None,
         }
     }
 }
@@ -185,6 +197,9 @@ pub struct InvokeModelRequest {
     /// protocol (Node's thinkingBudget).
     #[serde(default)]
     pub thinking_budget: Option<i32>,
+    /// Assistant voice for audio-output models (chat setting).
+    #[serde(default)]
+    pub voice: Option<String>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -195,6 +210,10 @@ pub struct ModelResponse {
     pub finish_reason: Option<String>,
     #[serde(default)]
     pub tool_calls: Vec<ToolCallRequest>,
+    /// Generated speech responses as `data:audio/...;base64,` URLs
+    /// (audio-output models).
+    #[serde(default)]
+    pub audios: Vec<String>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/api-rust/src/services/ai.rs
+++ b/api-rust/src/services/ai.rs
@@ -171,6 +171,20 @@ pub struct InvokeModelRequest {
     pub system_prompt: Option<String>,
     #[serde(default)]
     pub tools: Option<Vec<ExecutableTool>>,
+    /// Native provider tool types enabled on the chat (Node's ToolType
+    /// values, e.g. "web_search", "code_interpreter"). Serialized as
+    /// provider-native tool blocks by the OpenAI Responses protocol; other
+    /// protocols ignore them (they expose those capabilities as local
+    /// function tools instead).
+    #[serde(default)]
+    pub native_tools: Vec<String>,
+    /// Reasoning ("thinking") enabled for this request (chat setting).
+    #[serde(default)]
+    pub thinking: Option<bool>,
+    /// Reasoning token budget; mapped to an effort level by the Responses
+    /// protocol (Node's thinkingBudget).
+    #[serde(default)]
+    pub thinking_budget: Option<i32>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/api-rust/src/services/ai.rs
+++ b/api-rust/src/services/ai.rs
@@ -285,6 +285,12 @@ pub struct AIModelInfo {
     pub image_input: bool,
     #[serde(default)]
     pub max_input_tokens: Option<i32>,
+    /// Model capability flags surfaced to the client (Node's `ModelFeature`):
+    /// FILES_INPUT, AUDIO_INPUT, AUDIO_OUTPUT, REASONING, TEMPERATURE,
+    /// REQUEST_CANCELLATION, CACHE_RETENTION. Empty when the provider does
+    /// not classify features.
+    #[serde(default)]
+    pub features: Vec<String>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/api-rust/src/services/bedrock/bedrock_service.rs
+++ b/api-rust/src/services/bedrock/bedrock_service.rs
@@ -302,6 +302,7 @@ impl BedrockService {
             tool_calls: Some(assistant_content),
             tool_call_id: None,
             audio: None,
+            files: vec![],
         });
 
         let tools = session.tools.clone().unwrap_or_default();

--- a/api-rust/src/services/bedrock/bedrock_service.rs
+++ b/api-rust/src/services/bedrock/bedrock_service.rs
@@ -772,6 +772,9 @@ mod tests {
             top_p: Some(0.9),
             system_prompt: None,
             tools: None,
+            native_tools: vec![],
+            thinking: None,
+            thinking_budget: None,
         };
         let sanitized = sanitize_sampling_params(request);
         assert_eq!(sanitized.temperature, None);

--- a/api-rust/src/services/bedrock/bedrock_service.rs
+++ b/api-rust/src/services/bedrock/bedrock_service.rs
@@ -301,6 +301,7 @@ impl BedrockService {
             timestamp: None,
             tool_calls: Some(assistant_content),
             tool_call_id: None,
+            audio: None,
         });
 
         let tools = session.tools.clone().unwrap_or_default();
@@ -775,6 +776,7 @@ mod tests {
             native_tools: vec![],
             thinking: None,
             thinking_budget: None,
+            voice: None,
         };
         let sanitized = sanitize_sampling_params(request);
         assert_eq!(sanitized.temperature, None);

--- a/api-rust/src/services/bedrock/bedrock_service.rs
+++ b/api-rust/src/services/bedrock/bedrock_service.rs
@@ -45,6 +45,36 @@ pub(crate) struct BedrockModelConfig {
     pub supports_temperature: Option<bool>,
 }
 
+/// Bedrock model families that support extended reasoning ("thinking").
+/// Mirrors Node's `AWS_BEDROCK_MODELS_SUPPORT_REASONING`; substring-matched
+/// against the (geo-prefixed) invocation id.
+const BEDROCK_MODELS_SUPPORT_REASONING: &[&str] = &[
+    "anthropic.claude-opus-4",
+    "anthropic.claude-sonnet-4",
+    "anthropic.claude-sonnet-5",
+    "anthropic.claude-fable-5",
+    "anthropic.claude-haiku-4-5",
+    "anthropic.claude-3-7-sonnet",
+];
+
+/// Bedrock model families that support prompt cache retention
+/// (Node's `AWS_BEDROCK_MODELS_SUPPORT_CACHE_RETENTION`).
+const BEDROCK_MODELS_SUPPORT_CACHE_RETENTION: &[&str] = &[
+    "anthropic.claude-opus-4",
+    "anthropic.claude-sonnet-4",
+    "anthropic.claude-3-7-sonnet",
+    "anthropic.claude-3-5-haiku",
+    "anthropic.claude-3-5-sonnet",
+];
+
+/// Bedrock model families whose inline chat-context document blocks are
+/// implemented in api-rust. Node also advertises `amazon.nova`, but the Rust
+/// backend only formats native document blocks for the Anthropic (Claude)
+/// family (`providers/anthropic.rs`); the other families skip non-text files,
+/// so FILES_INPUT is only advertised for Claude here to keep the client's
+/// upload affordance honest.
+const BEDROCK_MODELS_SUPPORT_DOCUMENTS: &[&str] = &["anthropic.claude"];
+
 pub(crate) fn bedrock_model_configs() -> &'static HashMap<String, BedrockModelConfig> {
     static CONFIGS: std::sync::OnceLock<HashMap<String, BedrockModelConfig>> =
         std::sync::OnceLock::new();
@@ -651,6 +681,33 @@ impl AIProviderService for BedrockService {
 
                 let supports_image_in = model.input_modalities().contains(&ModelModality::Image);
 
+                // Capability flags surfaced to the client (Node parity —
+                // bedrock.provider.ts). Matched by substring against the
+                // (geo-prefixed) invocation id.
+                let mut features: Vec<String> = Vec::new();
+                if BEDROCK_MODELS_SUPPORT_REASONING
+                    .iter()
+                    .any(|m| effective_model_id.contains(m))
+                {
+                    features.push("REASONING".to_string());
+                }
+                if BEDROCK_MODELS_SUPPORT_CACHE_RETENTION
+                    .iter()
+                    .any(|m| effective_model_id.contains(m))
+                {
+                    features.push("CACHE_RETENTION".to_string());
+                }
+                if bedrock_supports_temperature(&effective_model_id) {
+                    features.push("TEMPERATURE".to_string());
+                }
+                if type_ == "chat"
+                    && BEDROCK_MODELS_SUPPORT_DOCUMENTS
+                        .iter()
+                        .any(|m| effective_model_id.contains(m))
+                {
+                    features.push("FILES_INPUT".to_string());
+                }
+
                 models.insert(
                     effective_model_id,
                     AIModelInfo {
@@ -662,6 +719,7 @@ impl AIProviderService for BedrockService {
                         streaming: supports_streaming,
                         image_input: supports_image_in,
                         max_input_tokens: model_config.max_input_tokens,
+                        features,
                     },
                 );
             }

--- a/api-rust/src/services/bedrock/providers/ai21.rs
+++ b/api-rust/src/services/bedrock/providers/ai21.rs
@@ -193,6 +193,7 @@ impl AI21Provider {
             content,
             model_id: model_id.to_string(),
             tool_calls: Vec::new(),
+            audios: vec![],
             usage,
             finish_reason: response
                 .get("choices")

--- a/api-rust/src/services/bedrock/providers/amazon.rs
+++ b/api-rust/src/services/bedrock/providers/amazon.rs
@@ -372,6 +372,7 @@ impl AmazonProvider {
             content,
             model_id: model_id.to_string(),
             tool_calls: Vec::new(),
+            audios: vec![],
             usage: None,
             finish_reason: None,
         })

--- a/api-rust/src/services/bedrock/providers/anthropic.rs
+++ b/api-rust/src/services/bedrock/providers/anthropic.rs
@@ -369,6 +369,9 @@ mod tests {
                     api_url: None,
                 },
             }]),
+            native_tools: vec![],
+            thinking: None,
+            thinking_budget: None,
         }
     }
 

--- a/api-rust/src/services/bedrock/providers/anthropic.rs
+++ b/api-rust/src/services/bedrock/providers/anthropic.rs
@@ -346,6 +346,7 @@ mod tests {
                         "name": "internal_web_search", "input": {"query": "rust"} }])),
                     tool_call_id: None,
                     audio: None,
+                    files: vec![],
                 },
                 ModelMessage {
                     role: AIMessageRole::Tool,
@@ -354,6 +355,7 @@ mod tests {
                     tool_calls: None,
                     tool_call_id: Some("t1".to_string()),
                     audio: None,
+                    files: vec![],
                 },
             ],
             temperature: None,

--- a/api-rust/src/services/bedrock/providers/anthropic.rs
+++ b/api-rust/src/services/bedrock/providers/anthropic.rs
@@ -222,10 +222,47 @@ impl AnthropicProvider {
                     }));
                 }
                 AIMessageRole::User => {
-                    messages.push(serde_json::json!({
-                        "role": "user",
-                        "content": msg.content,
-                    }));
+                    // A user turn with inline files serializes its content as
+                    // a blocks array: textual files inline as text, PDFs as a
+                    // native Anthropic `document` block (Claude on Bedrock is
+                    // the doc-capable family; other formats are skipped).
+                    if !msg.files.is_empty() {
+                        let mut parts: Vec<Value> = Vec::new();
+                        if !msg.content.is_empty() {
+                            parts.push(serde_json::json!({ "type": "text", "text": msg.content }));
+                        }
+                        for file in &msg.files {
+                            if let Some(text) = &file.text {
+                                parts.push(serde_json::json!({
+                                    "type": "text",
+                                    "text": format!("File \"{}\":\n\n{}", file.name, text),
+                                }));
+                            } else if let Some(base64) = &file.base64 {
+                                let mime = file.mime_type.split(';').next().unwrap_or("").trim();
+                                if mime == "application/pdf" {
+                                    parts.push(serde_json::json!({
+                                        "type": "document",
+                                        "source": {
+                                            "type": "base64",
+                                            "media_type": "application/pdf",
+                                            "data": base64,
+                                        },
+                                    }));
+                                } else {
+                                    tracing::warn!(
+                                        "Anthropic supports only PDF document blocks, skipping {}",
+                                        file.name
+                                    );
+                                }
+                            }
+                        }
+                        messages.push(serde_json::json!({ "role": "user", "content": parts }));
+                    } else {
+                        messages.push(serde_json::json!({
+                            "role": "user",
+                            "content": msg.content,
+                        }));
+                    }
                 }
             }
         }
@@ -391,6 +428,47 @@ mod tests {
         assert_eq!(body["messages"][2]["role"], "user");
         assert_eq!(body["messages"][2]["content"][0]["type"], "tool_result");
         assert_eq!(body["messages"][2]["content"][0]["tool_use_id"], "t1");
+    }
+
+    #[test]
+    fn formats_inline_file_document_blocks() {
+        use crate::services::ai::{ModelFile, ModelMessage};
+        let mut req = request_with_tools();
+        req.messages = vec![ModelMessage {
+            role: AIMessageRole::User,
+            content: "review".to_string(),
+            timestamp: None,
+            tool_calls: None,
+            tool_call_id: None,
+            audio: None,
+            files: vec![
+                ModelFile {
+                    s3_key: "c/m/notes.txt".to_string(),
+                    name: "notes.txt".to_string(),
+                    mime_type: "text/plain".to_string(),
+                    text: Some("hi".to_string()),
+                    base64: None,
+                },
+                ModelFile {
+                    s3_key: "c/m/doc.pdf".to_string(),
+                    name: "doc.pdf".to_string(),
+                    mime_type: "application/pdf".to_string(),
+                    text: None,
+                    base64: Some("QUJD".to_string()),
+                },
+            ],
+        }];
+        let body = AnthropicProvider::format_request(&req).unwrap();
+        let content = &body["messages"][0]["content"];
+        assert_eq!(content[0]["type"], "text"); // message text
+        assert_eq!(content[1]["type"], "text"); // textual file inlined
+        assert!(content[1]["text"]
+            .as_str()
+            .unwrap()
+            .contains("File \"notes.txt\""));
+        assert_eq!(content[2]["type"], "document");
+        assert_eq!(content[2]["source"]["media_type"], "application/pdf");
+        assert_eq!(content[2]["source"]["data"], "QUJD");
     }
 
     #[test]

--- a/api-rust/src/services/bedrock/providers/anthropic.rs
+++ b/api-rust/src/services/bedrock/providers/anthropic.rs
@@ -319,6 +319,7 @@ impl AnthropicProvider {
             model_id: model_id.to_string(),
             tool_calls,
             usage,
+            audios: vec![],
             finish_reason: response
                 .get("stop_reason")
                 .and_then(|r| r.as_str())
@@ -344,6 +345,7 @@ mod tests {
                     tool_calls: Some(json!([{ "type": "tool_use", "id": "t1",
                         "name": "internal_web_search", "input": {"query": "rust"} }])),
                     tool_call_id: None,
+                    audio: None,
                 },
                 ModelMessage {
                     role: AIMessageRole::Tool,
@@ -351,6 +353,7 @@ mod tests {
                     timestamp: None,
                     tool_calls: None,
                     tool_call_id: Some("t1".to_string()),
+                    audio: None,
                 },
             ],
             temperature: None,
@@ -372,6 +375,7 @@ mod tests {
             native_tools: vec![],
             thinking: None,
             thinking_budget: None,
+            voice: None,
         }
     }
 

--- a/api-rust/src/services/bedrock/providers/cohere.rs
+++ b/api-rust/src/services/bedrock/providers/cohere.rs
@@ -186,6 +186,7 @@ impl CohereProvider {
             content,
             model_id: model_id.to_string(),
             tool_calls: Vec::new(),
+            audios: vec![],
             usage,
             finish_reason: response
                 .get("finishReason")

--- a/api-rust/src/services/bedrock/providers/meta.rs
+++ b/api-rust/src/services/bedrock/providers/meta.rs
@@ -182,6 +182,7 @@ impl MetaProvider {
             content,
             model_id: model_id.to_string(),
             tool_calls: Vec::new(),
+            audios: vec![],
             usage: Some(Usage {
                 input_tokens: response
                     .get("prompt_token_count")

--- a/api-rust/src/services/bedrock/providers/mistral.rs
+++ b/api-rust/src/services/bedrock/providers/mistral.rs
@@ -187,6 +187,7 @@ impl MistralProvider {
             content,
             model_id: model_id.to_string(),
             tool_calls: Vec::new(),
+            audios: vec![],
             usage,
             finish_reason: choice
                 .and_then(|c| c.finish_reason.clone())

--- a/api-rust/src/services/chat.rs
+++ b/api-rust/src/services/chat.rs
@@ -97,6 +97,9 @@ impl<'a> ChatService<'a> {
                 c.is_pristine,
                 c.is_pinned,
                 c.folder_id,
+                c.voice,
+                c.thinking,
+                c.thinking_budget,
                 c.created_at,
                 c.updated_at
             FROM chats c

--- a/api-rust/src/services/custom.rs
+++ b/api-rust/src/services/custom.rs
@@ -18,9 +18,12 @@ use crate::utils::errors::AppError;
 /// Custom model protocols (subset of the Node API's `CustomModelProtocol`;
 /// the Responses API and Bedrock-custom variants are not ported yet).
 pub const PROTOCOL_OPENAI_CHAT_COMPLETIONS: &str = "OPENAI_CHAT_COMPLETIONS";
+pub const PROTOCOL_OPENAI_RESPONSES: &str = "OPENAI_RESPONSES";
 
 pub struct CustomService {
     protocol: OpenAIProtocol,
+    /// `protocol: OPENAI_RESPONSES` in the model's customSettings
+    use_responses: bool,
 }
 
 impl CustomService {
@@ -47,14 +50,16 @@ impl CustomService {
                 AppError::BadRequest("Endpoint URL is required for a custom model".to_string())
             })?;
 
-        if let Some(protocol) = settings.protocol.as_deref() {
-            if protocol != PROTOCOL_OPENAI_CHAT_COMPLETIONS {
+        let use_responses = match settings.protocol.as_deref() {
+            None | Some(PROTOCOL_OPENAI_CHAT_COMPLETIONS) => false,
+            Some(PROTOCOL_OPENAI_RESPONSES) => true,
+            Some(other) => {
                 return Err(AppError::BadRequest(format!(
-                    "Unsupported custom model protocol: {} (only {} is supported)",
-                    protocol, PROTOCOL_OPENAI_CHAT_COMPLETIONS
-                )));
+                    "Unsupported custom model protocol: {} (supported: {}, {})",
+                    other, PROTOCOL_OPENAI_CHAT_COMPLETIONS, PROTOCOL_OPENAI_RESPONSES
+                )))
             }
-        }
+        };
 
         Ok(Self {
             protocol: OpenAIProtocol::new(
@@ -63,6 +68,7 @@ impl CustomService {
                 settings.model_name.clone().filter(|m| !m.is_empty()),
                 "Custom model",
             ),
+            use_responses,
         })
     }
 }
@@ -70,6 +76,13 @@ impl CustomService {
 #[async_trait]
 impl AIProviderService for CustomService {
     async fn invoke_model(&self, request: InvokeModelRequest) -> Result<ModelResponse, AppError> {
+        if self.use_responses {
+            return crate::services::openai_responses::OpenAIResponsesProtocol::new(
+                self.protocol.clone(),
+            )
+            .invoke(&request)
+            .await;
+        }
         self.protocol.invoke(&request).await
     }
 
@@ -83,6 +96,13 @@ impl AIProviderService for CustomService {
         C: Fn(String) -> Pin<Box<dyn Future<Output = ()> + Send>> + Send + Sync,
         E: Fn(AppError) -> Pin<Box<dyn Future<Output = ()> + Send>> + Send + Sync,
     {
+        if self.use_responses {
+            return crate::services::openai_responses::OpenAIResponsesProtocol::new(
+                self.protocol.clone(),
+            )
+            .invoke_stream(&request, &callbacks)
+            .await;
+        }
         self.protocol.invoke_stream(&request, &callbacks).await
     }
 
@@ -158,8 +178,17 @@ mod tests {
     }
 
     #[test]
+    fn accepts_responses_protocol() {
+        let s = settings(
+            Some("http://localhost:11434/v1"),
+            Some(PROTOCOL_OPENAI_RESPONSES),
+        );
+        assert!(CustomService::from_settings(&s).is_ok());
+    }
+
+    #[test]
     fn rejects_unknown_protocol() {
-        let s = settings(Some("http://localhost:11434/v1"), Some("OPENAI_RESPONSES"));
+        let s = settings(Some("http://localhost:11434/v1"), Some("GRPC"));
         assert!(CustomService::from_settings(&s).is_err());
     }
 }

--- a/api-rust/src/services/document_index.rs
+++ b/api-rust/src/services/document_index.rs
@@ -341,6 +341,7 @@ async fn index_document(
                         native_tools: vec![],
                         thinking: None,
                         thinking_budget: None,
+                        voice: None,
                     })
                     .await?;
 

--- a/api-rust/src/services/document_index.rs
+++ b/api-rust/src/services/document_index.rs
@@ -338,6 +338,9 @@ async fn index_document(
                         top_p: None,
                         system_prompt: None,
                         tools: None,
+                        native_tools: vec![],
+                        thinking: None,
+                        thinking_budget: None,
                     })
                     .await?;
 

--- a/api-rust/src/services/mail.rs
+++ b/api-rust/src/services/mail.rs
@@ -1,0 +1,90 @@
+//! SMTP mailer for password-reset emails (Node's mail.service).
+
+use lettre::message::header::ContentType;
+use lettre::transport::smtp::authentication::Credentials;
+use lettre::{AsyncSmtpTransport, AsyncTransport, Message, Tokio1Executor};
+
+use crate::config::AppConfig;
+use crate::utils::errors::AppError;
+
+pub fn smtp_enabled(config: &AppConfig) -> bool {
+    config.smtp_host.is_some()
+}
+
+pub async fn send_password_reset_email(
+    config: &AppConfig,
+    to: &str,
+    reset_url: &str,
+) -> Result<(), AppError> {
+    let Some(host) = config.smtp_host.as_deref() else {
+        return Ok(()); // no-op when SMTP is not configured (Node parity)
+    };
+
+    let html = format!(
+        "<div style=\"font-family: Arial, sans-serif; max-width: 600px; margin: 0 auto;\">\
+         <h2>Reset your password</h2>\
+         <p>You requested a password reset for your KateChat account.</p>\
+         <p>Click the button below to set a new password. This link is valid for 15 minutes.</p>\
+         <p><a href=\"{url}\" style=\"display:inline-block;padding:10px 20px;background:#228be6;\
+         color:#fff;text-decoration:none;border-radius:4px;\">Reset password</a></p>\
+         <p>If the button does not work, copy this link into your browser:<br/>{url}</p>\
+         <p>If you did not request a reset, you can safely ignore this email.</p>\
+         </div>",
+        url = reset_url
+    );
+
+    let email = Message::builder()
+        .from(
+            config
+                .smtp_from
+                .parse()
+                .map_err(|e| AppError::Internal(format!("Invalid SMTP_FROM: {}", e)))?,
+        )
+        .to(to
+            .parse()
+            .map_err(|e| AppError::Validation(format!("Invalid recipient: {}", e)))?)
+        .subject("Reset your password")
+        .header(ContentType::TEXT_HTML)
+        .body(html)
+        .map_err(|e| AppError::Internal(format!("Failed to build email: {}", e)))?;
+
+    // SMTP_SECURE=true → implicit TLS (465); otherwise STARTTLS when the
+    // server offers it (587), like nodemailer's default behavior
+    let mut builder = if config.smtp_secure {
+        AsyncSmtpTransport::<Tokio1Executor>::relay(host)
+            .map_err(|e| AppError::Internal(format!("SMTP relay: {}", e)))?
+    } else {
+        AsyncSmtpTransport::<Tokio1Executor>::starttls_relay(host)
+            .map_err(|e| AppError::Internal(format!("SMTP relay: {}", e)))?
+    }
+    .port(config.smtp_port);
+
+    if let (Some(user), Some(password)) = (&config.smtp_user, &config.smtp_password) {
+        builder = builder.credentials(Credentials::new(user.clone(), password.clone()));
+    }
+
+    builder
+        .build()
+        .send(email)
+        .await
+        .map_err(|e| AppError::Internal(format!("Failed to send email: {}", e)))?;
+    Ok(())
+}
+
+/// Verify a Google reCAPTCHA token (Node's verifyRecaptchaToken).
+pub async fn verify_recaptcha(secret: &str, token: &str) -> Result<bool, AppError> {
+    let response = reqwest::Client::new()
+        .post("https://www.google.com/recaptcha/api/siteverify")
+        .form(&[("secret", secret), ("response", token)])
+        .send()
+        .await
+        .map_err(|e| AppError::Internal(format!("reCAPTCHA request failed: {}", e)))?;
+    let body: serde_json::Value = response
+        .json()
+        .await
+        .map_err(|e| AppError::Internal(format!("reCAPTCHA response: {}", e)))?;
+    Ok(body
+        .get("success")
+        .and_then(|s| s.as_bool())
+        .unwrap_or(false))
+}

--- a/api-rust/src/services/mod.rs
+++ b/api-rust/src/services/mod.rs
@@ -9,6 +9,7 @@ pub mod mcp;
 pub mod model;
 pub mod openai;
 pub mod openai_protocol;
+pub mod openai_responses;
 pub mod pubsub;
 pub mod rag;
 pub mod realtime;

--- a/api-rust/src/services/mod.rs
+++ b/api-rust/src/services/mod.rs
@@ -4,6 +4,7 @@ pub mod chat;
 pub mod custom;
 pub mod document_index;
 pub mod document_status_redis;
+pub mod mail;
 pub mod mcp;
 pub mod model;
 pub mod openai;

--- a/api-rust/src/services/mod.rs
+++ b/api-rust/src/services/mod.rs
@@ -11,6 +11,7 @@ pub mod openai;
 pub mod openai_protocol;
 pub mod pubsub;
 pub mod rag;
+pub mod realtime;
 pub mod s3;
 pub mod sqs;
 pub mod tools;

--- a/api-rust/src/services/model.rs
+++ b/api-rust/src/services/model.rs
@@ -85,7 +85,9 @@ impl<'a> ModelService<'a> {
                 tools: (model_info.type_ == "chat")
                     .then(|| chat_tools.clone())
                     .flatten(),
-                features: None,
+                features: (!model_info.features.is_empty())
+                    .then(|| serde_json::to_string(&model_info.features).ok())
+                    .flatten(),
                 custom_settings: None,
                 is_active,
                 is_custom: false,

--- a/api-rust/src/services/openai.rs
+++ b/api-rust/src/services/openai.rs
@@ -79,6 +79,13 @@ impl OpenAIService {
 #[async_trait]
 impl AIProviderService for OpenAIService {
     async fn invoke_model(&self, request: InvokeModelRequest) -> Result<ModelResponse, AppError> {
+        if crate::services::openai_responses::uses_responses_api(&request.model_id) {
+            return crate::services::openai_responses::OpenAIResponsesProtocol::new(
+                self.protocol()?,
+            )
+            .invoke(&request)
+            .await;
+        }
         self.protocol()?.invoke(&request).await
     }
 
@@ -92,6 +99,13 @@ impl AIProviderService for OpenAIService {
         C: Fn(String) -> Pin<Box<dyn Future<Output = ()> + Send>> + Send + Sync,
         E: Fn(AppError) -> Pin<Box<dyn Future<Output = ()> + Send>> + Send + Sync,
     {
+        if crate::services::openai_responses::uses_responses_api(&request.model_id) {
+            return crate::services::openai_responses::OpenAIResponsesProtocol::new(
+                self.protocol()?,
+            )
+            .invoke_stream(&request, &callbacks)
+            .await;
+        }
         self.protocol()?.invoke_stream(&request, &callbacks).await
     }
 

--- a/api-rust/src/services/openai.rs
+++ b/api-rust/src/services/openai.rs
@@ -64,6 +64,12 @@ impl OpenAIService {
         if model_id.starts_with("text-embedding") {
             return Some(("embedding", false, false));
         }
+        // Realtime voice models (gpt-4o-realtime, gpt-realtime, …) are a
+        // distinct model type (Node's ModelType.REALTIME) — they back the
+        // voice-to-voice sessions, not the chat list.
+        if model_id.contains("-realtime") {
+            return Some(("realtime", false, false));
+        }
         // Audio-input chat models (gpt-4o-audio, gpt-audio, …) reply with
         // speech; they are chat models even though the id contains "audio".
         if is_audio_input_model(model_id) {
@@ -71,14 +77,7 @@ impl OpenAIService {
         }
         if model_id.contains("gpt") || model_id.starts_with("o1") || model_id.starts_with("o3") {
             // exclude non-chat specializations kept out of the chat list
-            for skip in [
-                "instruct",
-                "realtime",
-                "audio",
-                "tts",
-                "transcribe",
-                "search",
-            ] {
+            for skip in ["instruct", "audio", "tts", "transcribe", "search"] {
                 if model_id.contains(skip) {
                     return None;
                 }
@@ -250,12 +249,26 @@ mod tests {
 
     #[test]
     fn skips_non_chat_specializations() {
-        assert_eq!(
-            OpenAIService::classify_model("gpt-4o-realtime-preview"),
-            None
-        );
         assert_eq!(OpenAIService::classify_model("whisper-1"), None);
         assert_eq!(OpenAIService::classify_model("tts-1"), None);
+    }
+
+    #[test]
+    fn realtime_models_are_realtime_type() {
+        // Voice-to-voice models are listed as a distinct realtime type so
+        // createRealtimeSession can find them (they survive reloadModels).
+        assert_eq!(
+            OpenAIService::classify_model("gpt-4o-realtime-preview"),
+            Some(("realtime", false, false))
+        );
+        assert_eq!(
+            OpenAIService::classify_model("gpt-realtime"),
+            Some(("realtime", false, false))
+        );
+        assert_eq!(
+            OpenAIService::classify_model("gpt-4o-mini-realtime-preview"),
+            Some(("realtime", false, false))
+        );
     }
 
     #[test]

--- a/api-rust/src/services/openai.rs
+++ b/api-rust/src/services/openai.rs
@@ -19,6 +19,16 @@ const OPENAI_API_URL: &str = "https://api.openai.com/v1";
 const IMAGES_GENERATION_PREFIXES: &[&str] = &["dall-e", "chatgpt-image", "gpt-image"];
 /// Chat-model prefixes that accept image input.
 const IMAGE_INPUT_PREFIXES: &[&str] = &["gpt-4o", "gpt-4.1", "gpt-4-turbo", "gpt-5", "o3", "o4"];
+/// Chat models that accept voice recordings as input and reply with speech
+/// (Node's `OPENAI_MODELS_AUDIO_INPUT`). Prefix-matched.
+pub const OPENAI_MODELS_AUDIO_INPUT: &[&str] = &["gpt-4o-audio", "gpt-4o-mini-audio", "gpt-audio"];
+
+/// True when `model_id` is an audio-input (speech in/out) chat model.
+pub fn is_audio_input_model(model_id: &str) -> bool {
+    OPENAI_MODELS_AUDIO_INPUT
+        .iter()
+        .any(|p| model_id.starts_with(p))
+}
 
 pub struct OpenAIService {
     config: AppConfig,
@@ -54,6 +64,11 @@ impl OpenAIService {
         if model_id.starts_with("text-embedding") {
             return Some(("embedding", false, false));
         }
+        // Audio-input chat models (gpt-4o-audio, gpt-audio, …) reply with
+        // speech; they are chat models even though the id contains "audio".
+        if is_audio_input_model(model_id) {
+            return Some(("chat", true, false));
+        }
         if model_id.contains("gpt") || model_id.starts_with("o1") || model_id.starts_with("o3") {
             // exclude non-chat specializations kept out of the chat list
             for skip in [
@@ -79,7 +94,9 @@ impl OpenAIService {
 #[async_trait]
 impl AIProviderService for OpenAIService {
     async fn invoke_model(&self, request: InvokeModelRequest) -> Result<ModelResponse, AppError> {
-        if crate::services::openai_responses::uses_responses_api(&request.model_id) {
+        if !is_audio_input_model(&request.model_id)
+            && crate::services::openai_responses::uses_responses_api(&request.model_id)
+        {
             return crate::services::openai_responses::OpenAIResponsesProtocol::new(
                 self.protocol()?,
             )
@@ -99,7 +116,9 @@ impl AIProviderService for OpenAIService {
         C: Fn(String) -> Pin<Box<dyn Future<Output = ()> + Send>> + Send + Sync,
         E: Fn(AppError) -> Pin<Box<dyn Future<Output = ()> + Send>> + Send + Sync,
     {
-        if crate::services::openai_responses::uses_responses_api(&request.model_id) {
+        if !is_audio_input_model(&request.model_id)
+            && crate::services::openai_responses::uses_responses_api(&request.model_id)
+        {
             return crate::services::openai_responses::OpenAIResponsesProtocol::new(
                 self.protocol()?,
             )
@@ -235,8 +254,22 @@ mod tests {
             OpenAIService::classify_model("gpt-4o-realtime-preview"),
             None
         );
-        assert_eq!(OpenAIService::classify_model("gpt-4o-audio-preview"), None);
         assert_eq!(OpenAIService::classify_model("whisper-1"), None);
         assert_eq!(OpenAIService::classify_model("tts-1"), None);
+    }
+
+    #[test]
+    fn audio_input_models_are_chat() {
+        // Audio-input models are chat models even though the id says "audio".
+        assert_eq!(
+            OpenAIService::classify_model("gpt-4o-audio-preview"),
+            Some(("chat", true, false))
+        );
+        assert_eq!(
+            OpenAIService::classify_model("gpt-audio"),
+            Some(("chat", true, false))
+        );
+        assert!(is_audio_input_model("gpt-4o-mini-audio"));
+        assert!(!is_audio_input_model("gpt-4o"));
     }
 }

--- a/api-rust/src/services/openai.rs
+++ b/api-rust/src/services/openai.rs
@@ -22,6 +22,9 @@ const IMAGE_INPUT_PREFIXES: &[&str] = &["gpt-4o", "gpt-4.1", "gpt-4-turbo", "gpt
 /// Chat models that accept voice recordings as input and reply with speech
 /// (Node's `OPENAI_MODELS_AUDIO_INPUT`). Prefix-matched.
 pub const OPENAI_MODELS_AUDIO_INPUT: &[&str] = &["gpt-4o-audio", "gpt-4o-mini-audio", "gpt-audio"];
+/// Chat-model prefixes that support reasoning ("thinking") effort
+/// (Node's `OPENAI_MODELS_SUPPORT_REASONING`).
+const OPENAI_MODELS_SUPPORT_REASONING: &[&str] = &["gpt-5", "o1", "o3", "o4"];
 
 /// True when `model_id` is an audio-input (speech in/out) chat model.
 pub fn is_audio_input_model(model_id: &str) -> bool {
@@ -88,6 +91,40 @@ impl OpenAIService {
         }
         None
     }
+
+    /// Capability flags surfaced to the client (Node's `ModelFeature`),
+    /// mirroring `openai.provider.ts`:
+    /// - REQUEST_CANCELLATION + CACHE_RETENTION for Responses-API models
+    /// - REASONING for gpt-5 / o-series
+    /// - AUDIO_INPUT + AUDIO_OUTPUT for audio-input models
+    /// - FILES_INPUT for chat models on the Responses API or with image input
+    /// - TEMPERATURE always
+    fn model_features(model_id: &str, type_: &str, image_input: bool) -> Vec<String> {
+        let responses = crate::services::openai_responses::uses_responses_api(model_id)
+            && !is_audio_input_model(model_id);
+        let mut features: Vec<String> = Vec::new();
+        if responses {
+            features.push("REQUEST_CANCELLATION".to_string());
+            features.push("CACHE_RETENTION".to_string());
+        }
+        if OPENAI_MODELS_SUPPORT_REASONING
+            .iter()
+            .any(|p| model_id.starts_with(p))
+        {
+            features.push("REASONING".to_string());
+        }
+        if is_audio_input_model(model_id) {
+            features.push("AUDIO_INPUT".to_string());
+            features.push("AUDIO_OUTPUT".to_string());
+        }
+        // PDF input: input_file blocks on the Responses API, file blocks on
+        // vision-capable Completions models.
+        if type_ == "chat" && (responses || image_input) {
+            features.push("FILES_INPUT".to_string());
+        }
+        features.push("TEMPERATURE".to_string());
+        features
+    }
 }
 
 #[async_trait]
@@ -137,6 +174,7 @@ impl AIProviderService for OpenAIService {
         let mut models = HashMap::new();
         for id in ids {
             if let Some((type_, streaming, image_input)) = Self::classify_model(&id) {
+                let features = Self::model_features(&id, type_, image_input);
                 models.insert(
                     id.clone(),
                     AIModelInfo {
@@ -148,6 +186,7 @@ impl AIProviderService for OpenAIService {
                         streaming,
                         image_input,
                         max_input_tokens: None,
+                        features,
                     },
                 );
             }
@@ -269,6 +308,32 @@ mod tests {
             OpenAIService::classify_model("gpt-4o-mini-realtime-preview"),
             Some(("realtime", false, false))
         );
+    }
+
+    #[test]
+    fn model_features_mirror_node() {
+        // Responses-API reasoning model with image input: cancellation +
+        // cache + reasoning + files + temperature.
+        let f = OpenAIService::model_features("gpt-5.5-pro", "chat", true);
+        assert!(f.contains(&"REQUEST_CANCELLATION".to_string()));
+        assert!(f.contains(&"CACHE_RETENTION".to_string()));
+        assert!(f.contains(&"REASONING".to_string()));
+        assert!(f.contains(&"FILES_INPUT".to_string()));
+        assert!(f.contains(&"TEMPERATURE".to_string()));
+        assert!(!f.contains(&"AUDIO_INPUT".to_string()));
+
+        // Audio-input model: audio in/out + temperature, but no files
+        // (not a Responses model, no image input) and no reasoning.
+        let a = OpenAIService::model_features("gpt-4o-audio-preview", "chat", false);
+        assert!(a.contains(&"AUDIO_INPUT".to_string()));
+        assert!(a.contains(&"AUDIO_OUTPUT".to_string()));
+        assert!(a.contains(&"TEMPERATURE".to_string()));
+        assert!(!a.contains(&"FILES_INPUT".to_string()));
+        assert!(!a.contains(&"REASONING".to_string()));
+
+        // Embedding model: just temperature (Node pushes it unconditionally).
+        let e = OpenAIService::model_features("text-embedding-3-small", "embedding", false);
+        assert!(!e.contains(&"FILES_INPUT".to_string()));
     }
 
     #[test]

--- a/api-rust/src/services/openai_protocol.rs
+++ b/api-rust/src/services/openai_protocol.rs
@@ -18,6 +18,7 @@ use crate::services::ai::{
 use crate::services::tools::execute_tool_call;
 use crate::utils::errors::AppError;
 
+#[derive(Clone)]
 pub struct OpenAIProtocol {
     client: Client,
     /// e.g. `https://api.openai.com/v1`, `https://ai.api.cloud.yandex.net/v1`
@@ -66,11 +67,11 @@ impl OpenAIProtocol {
             .unwrap_or_else(|| requested.to_string())
     }
 
-    fn url(&self, path: &str) -> String {
+    pub(crate) fn url(&self, path: &str) -> String {
         format!("{}{}", self.base_url, path)
     }
 
-    fn post(&self, path: &str) -> reqwest::RequestBuilder {
+    pub(crate) fn post(&self, path: &str) -> reqwest::RequestBuilder {
         let mut builder = self
             .client
             .post(self.url(path))
@@ -90,7 +91,7 @@ impl OpenAIProtocol {
     }
 
     /// Extract the API error message from an OpenAI-style error payload.
-    fn api_error(&self, status: reqwest::StatusCode, body: &str) -> AppError {
+    pub(crate) fn api_error(&self, status: reqwest::StatusCode, body: &str) -> AppError {
         let message = serde_json::from_str::<Value>(body)
             .ok()
             .and_then(|v| {

--- a/api-rust/src/services/openai_protocol.rs
+++ b/api-rust/src/services/openai_protocol.rs
@@ -663,6 +663,9 @@ mod tests {
             top_p: None,
             system_prompt: Some("be brief".to_string()),
             tools: None,
+            native_tools: vec![],
+            thinking: None,
+            thinking_budget: None,
         }
     }
 

--- a/api-rust/src/services/openai_protocol.rs
+++ b/api-rust/src/services/openai_protocol.rs
@@ -144,21 +144,42 @@ impl OpenAIProtocol {
                         MessageRole::System => "system",
                         _ => "user",
                     };
-                    // A user turn carrying a voice recording serializes its
-                    // content as an array with an `input_audio` block.
-                    if matches!(msg.role, MessageRole::User) {
+                    // A user turn carrying a voice recording or inline files
+                    // serializes its content as a parts array.
+                    if matches!(msg.role, MessageRole::User)
+                        && (msg.audio.is_some() || !msg.files.is_empty())
+                    {
+                        let mut parts = Vec::new();
+                        if !msg.content.is_empty() {
+                            parts.push(json!({ "type": "text", "text": msg.content }));
+                        }
                         if let Some(audio) = &msg.audio {
-                            let mut parts = Vec::new();
-                            if !msg.content.is_empty() {
-                                parts.push(json!({ "type": "text", "text": msg.content }));
-                            }
                             parts.push(json!({
                                 "type": "input_audio",
                                 "input_audio": { "data": audio.data_base64, "format": audio.format },
                             }));
-                            messages.push(json!({ "role": role, "content": parts }));
-                            continue;
                         }
+                        // Inline files: textual mimes are sent as text, PDFs as
+                        // a `file` block (rides on vision support — the caller
+                        // only preloads base64 for image-capable models).
+                        for file in &msg.files {
+                            if let Some(text) = &file.text {
+                                parts.push(json!({
+                                    "type": "text",
+                                    "text": format!("File \"{}\":\n\n{}", file.name, text),
+                                }));
+                            } else if let Some(base64) = &file.base64 {
+                                parts.push(json!({
+                                    "type": "file",
+                                    "file": {
+                                        "filename": file.name,
+                                        "file_data": format!("data:{};base64,{}", file.mime_type, base64),
+                                    },
+                                }));
+                            }
+                        }
+                        messages.push(json!({ "role": role, "content": parts }));
+                        continue;
                     }
                     messages.push(json!({ "role": role, "content": msg.content }));
                 }
@@ -270,6 +291,7 @@ impl OpenAIProtocol {
             tool_calls: Some(Value::Array(raw_calls)),
             tool_call_id: None,
             audio: None,
+            files: vec![],
         });
 
         let tools = session.tools.clone().unwrap_or_default();
@@ -743,6 +765,7 @@ mod tests {
                 data_base64: "QUJD".to_string(),
                 format: "wav".to_string(),
             }),
+            files: vec![],
         }];
         let body = protocol.build_completion_body(&req, false);
         let content = &body["messages"][1]["content"];
@@ -757,6 +780,50 @@ mod tests {
         // streaming uses pcm16
         let stream_body = protocol.build_completion_body(&req, true);
         assert_eq!(stream_body["audio"]["format"], "pcm16");
+    }
+
+    #[test]
+    fn inline_files_serialize_text_and_pdf_blocks() {
+        let protocol = OpenAIProtocol::new("https://api.openai.com/v1/", None, None, "OpenAI");
+        let mut req = request();
+        req.messages = vec![crate::services::ai::ModelMessage {
+            role: MessageRole::User,
+            content: "review these".to_string(),
+            timestamp: None,
+            tool_calls: None,
+            tool_call_id: None,
+            audio: None,
+            files: vec![
+                crate::services::ai::ModelFile {
+                    s3_key: "c/m/notes.txt".to_string(),
+                    name: "notes.txt".to_string(),
+                    mime_type: "text/plain".to_string(),
+                    text: Some("hello".to_string()),
+                    base64: None,
+                },
+                crate::services::ai::ModelFile {
+                    s3_key: "c/m/doc.pdf".to_string(),
+                    name: "doc.pdf".to_string(),
+                    mime_type: "application/pdf".to_string(),
+                    text: None,
+                    base64: Some("QUJD".to_string()),
+                },
+            ],
+        }];
+        let body = protocol.build_completion_body(&req, false);
+        let content = &body["messages"][1]["content"];
+        assert_eq!(content[0]["type"], "text"); // leading message text
+        assert_eq!(content[1]["type"], "text"); // textual file inlined
+        assert!(content[1]["text"]
+            .as_str()
+            .unwrap()
+            .contains("File \"notes.txt\""));
+        assert_eq!(content[2]["type"], "file");
+        assert_eq!(content[2]["file"]["filename"], "doc.pdf");
+        assert_eq!(
+            content[2]["file"]["file_data"],
+            "data:application/pdf;base64,QUJD"
+        );
     }
 
     #[test]
@@ -818,6 +885,7 @@ mod tests {
                 "function": {"name": "internal_web_search", "arguments": "{}"}}])),
             tool_call_id: None,
             audio: None,
+            files: vec![],
         });
         req.messages.push(ModelMessage {
             role: MessageRole::Tool,
@@ -826,6 +894,7 @@ mod tests {
             tool_calls: None,
             tool_call_id: Some("c1".to_string()),
             audio: None,
+            files: vec![],
         });
 
         let body = protocol.build_completion_body(&req, false);

--- a/api-rust/src/services/openai_protocol.rs
+++ b/api-rust/src/services/openai_protocol.rs
@@ -144,6 +144,22 @@ impl OpenAIProtocol {
                         MessageRole::System => "system",
                         _ => "user",
                     };
+                    // A user turn carrying a voice recording serializes its
+                    // content as an array with an `input_audio` block.
+                    if matches!(msg.role, MessageRole::User) {
+                        if let Some(audio) = &msg.audio {
+                            let mut parts = Vec::new();
+                            if !msg.content.is_empty() {
+                                parts.push(json!({ "type": "text", "text": msg.content }));
+                            }
+                            parts.push(json!({
+                                "type": "input_audio",
+                                "input_audio": { "data": audio.data_base64, "format": audio.format },
+                            }));
+                            messages.push(json!({ "role": role, "content": parts }));
+                            continue;
+                        }
+                    }
                     messages.push(json!({ "role": role, "content": msg.content }));
                 }
             }
@@ -193,6 +209,19 @@ impl OpenAIProtocol {
                 .collect::<Vec<_>>());
         }
 
+        // Audio-output models: request speech alongside text. Streaming only
+        // supports pcm16 deltas; the sync path returns mp3 (Node parity).
+        if crate::services::openai::is_audio_input_model(&model_id) {
+            let voice = request
+                .voice
+                .as_deref()
+                .filter(|v| crate::services::realtime::OPENAI_REALTIME_VOICES.contains(v))
+                .unwrap_or(crate::services::realtime::OPENAI_REALTIME_DEFAULT_VOICE);
+            let format = if stream { "pcm16" } else { "mp3" };
+            body["modalities"] = json!(["text", "audio"]);
+            body["audio"] = json!({ "voice": voice, "format": format });
+        }
+
         body
     }
 
@@ -240,6 +269,7 @@ impl OpenAIProtocol {
             timestamp: None,
             tool_calls: Some(Value::Array(raw_calls)),
             tool_call_id: None,
+            audio: None,
         });
 
         let tools = session.tools.clone().unwrap_or_default();
@@ -311,11 +341,25 @@ impl OpenAIProtocol {
                 continue;
             }
 
-            let content = message
+            let mut content = message
                 .and_then(|msg| msg.get("content"))
                 .and_then(|content| content.as_str())
                 .unwrap_or("")
                 .to_string();
+
+            // Audio-output models return { audio: { data, transcript } };
+            // the transcript stands in for text when content is empty.
+            let mut audios = Vec::new();
+            if let Some(audio) = message.and_then(|msg| msg.get("audio")) {
+                if let Some(data) = audio.get("data").and_then(|d| d.as_str()) {
+                    audios.push(format!("data:audio/mpeg;base64,{}", data));
+                }
+                if content.is_empty() {
+                    if let Some(transcript) = audio.get("transcript").and_then(|t| t.as_str()) {
+                        content = transcript.to_string();
+                    }
+                }
+            }
 
             let finish_reason = first_choice
                 .and_then(|choice| choice.get("finish_reason"))
@@ -328,6 +372,7 @@ impl OpenAIProtocol {
                 usage: response_json.get("usage").map(Self::parse_usage),
                 finish_reason,
                 tool_calls: Vec::new(),
+                audios,
             });
         }
 
@@ -666,6 +711,7 @@ mod tests {
             native_tools: vec![],
             thinking: None,
             thinking_budget: None,
+            voice: None,
         }
     }
 
@@ -679,6 +725,38 @@ mod tests {
         assert_eq!(body["temperature"], 0.5);
         assert_eq!(body["max_tokens"], 100);
         assert!(body.get("stream").is_none());
+    }
+
+    #[test]
+    fn audio_input_serializes_input_audio_block_and_output_request() {
+        let protocol = OpenAIProtocol::new("https://api.openai.com/v1/", None, None, "OpenAI");
+        let mut req = request();
+        req.model_id = "gpt-4o-audio-preview".to_string();
+        req.voice = Some("verse".to_string());
+        req.messages = vec![crate::services::ai::ModelMessage {
+            role: MessageRole::User,
+            content: "transcribe this".to_string(),
+            timestamp: None,
+            tool_calls: None,
+            tool_call_id: None,
+            audio: Some(crate::services::ai::ModelAudio {
+                data_base64: "QUJD".to_string(),
+                format: "wav".to_string(),
+            }),
+        }];
+        let body = protocol.build_completion_body(&req, false);
+        let content = &body["messages"][1]["content"];
+        assert_eq!(content[0]["type"], "text");
+        assert_eq!(content[1]["type"], "input_audio");
+        assert_eq!(content[1]["input_audio"]["format"], "wav");
+        assert_eq!(content[1]["input_audio"]["data"], "QUJD");
+        // audio output requested, voice honored, mp3 for the sync path
+        assert_eq!(body["modalities"][1], "audio");
+        assert_eq!(body["audio"]["voice"], "verse");
+        assert_eq!(body["audio"]["format"], "mp3");
+        // streaming uses pcm16
+        let stream_body = protocol.build_completion_body(&req, true);
+        assert_eq!(stream_body["audio"]["format"], "pcm16");
     }
 
     #[test]
@@ -739,6 +817,7 @@ mod tests {
             tool_calls: Some(json!([{"id": "c1", "type": "function",
                 "function": {"name": "internal_web_search", "arguments": "{}"}}])),
             tool_call_id: None,
+            audio: None,
         });
         req.messages.push(ModelMessage {
             role: MessageRole::Tool,
@@ -746,6 +825,7 @@ mod tests {
             timestamp: None,
             tool_calls: None,
             tool_call_id: Some("c1".to_string()),
+            audio: None,
         });
 
         let body = protocol.build_completion_body(&req, false);

--- a/api-rust/src/services/openai_responses.rs
+++ b/api-rust/src/services/openai_responses.rs
@@ -1,0 +1,500 @@
+//! OpenAI Responses API protocol (`POST /responses`) — Node's
+//! OpenAIResponsesProtocol. Used for OpenAI models that support the
+//! Responses API (gpt-5 / gpt-4.1 / gpt-4o / o-series) and for custom
+//! models configured with `protocol: OPENAI_RESPONSES`.
+//!
+//! Tool calling runs through `previous_response_id` + `function_call_output`
+//! items rather than replayed chat history; local tools (web search, MCP)
+//! are exposed as `function` tools like the chat-completions path.
+
+use futures_util::StreamExt;
+use serde_json::{json, Value};
+use std::future::Future;
+use std::pin::Pin;
+use tracing::{debug, warn};
+
+use crate::services::ai::{
+    ExecutedToolCall, InvokeModelRequest, MessageRole, ModelResponse, StreamCallbacks,
+    ToolCallRequest, Usage, TOOL_CYCLES_LIMIT,
+};
+use crate::services::openai_protocol::OpenAIProtocol;
+use crate::services::tools::execute_tool_call;
+use crate::utils::errors::AppError;
+
+/// Models served through the Responses API (Node's
+/// OPENAI_MODELS_SUPPORT_RESPONSES_API, prefix-matched).
+pub const RESPONSES_MODEL_PREFIXES: &[&str] =
+    &["gpt-5", "gpt-4.1", "gpt-4o", "o1", "o3", "o4-mini"];
+
+/// Reasoning models reject sampling params (Node deletes temperature).
+const NO_SAMPLING_PREFIXES: &[&str] = &["o1", "o3", "o4", "gpt-4o", "gpt-5"];
+
+pub fn uses_responses_api(model_id: &str) -> bool {
+    RESPONSES_MODEL_PREFIXES.iter().any(|p| {
+        model_id == *p || model_id.starts_with(&format!("{}-", p)) || model_id.starts_with(*p)
+    })
+}
+
+pub struct OpenAIResponsesProtocol {
+    inner: OpenAIProtocol,
+}
+
+impl OpenAIResponsesProtocol {
+    pub fn new(inner: OpenAIProtocol) -> Self {
+        Self { inner }
+    }
+
+    /// Build the `POST /responses` body from an invoke request.
+    pub fn build_responses_body(&self, request: &InvokeModelRequest, stream: bool) -> Value {
+        let model = self.inner.effective_model_id(&request.model_id);
+
+        let input: Vec<Value> = request
+            .messages
+            .iter()
+            .filter(|m| !matches!(m.role, MessageRole::Tool))
+            .map(|m| {
+                let role = match m.role {
+                    MessageRole::User => "user",
+                    MessageRole::Assistant => "assistant",
+                    MessageRole::System => "developer",
+                    MessageRole::Tool => unreachable!(),
+                };
+                json!({ "role": role, "content": m.content })
+            })
+            .collect();
+
+        let mut body = json!({ "model": model, "input": input });
+        if stream {
+            body["stream"] = json!(true);
+        }
+        if let Some(prompt) = request.system_prompt.as_deref().filter(|p| !p.is_empty()) {
+            body["instructions"] = json!(prompt);
+        }
+        if let Some(max_tokens) = request.max_tokens {
+            body["max_output_tokens"] = json!(max_tokens.max(16));
+        }
+        let no_sampling = NO_SAMPLING_PREFIXES.iter().any(|p| model.starts_with(p));
+        if !no_sampling {
+            if let Some(temperature) = request.temperature {
+                body["temperature"] = json!(temperature);
+            }
+        }
+        if model.starts_with("gpt-5") {
+            body["reasoning"] = json!({ "effort": "minimal" });
+        }
+        if let Some(tools) = request.tools.as_deref().filter(|t| !t.is_empty()) {
+            body["tools"] = Value::Array(
+                tools
+                    .iter()
+                    .map(|tool| {
+                        json!({
+                            "type": "function",
+                            "name": tool.spec.name,
+                            "description": tool.spec.description,
+                            "parameters": tool.spec.input_schema,
+                            "strict": false,
+                        })
+                    })
+                    .collect(),
+            );
+        }
+        body
+    }
+
+    fn parse_output(response: &Value) -> (String, Vec<ToolCallRequest>) {
+        let mut content = String::new();
+        let mut calls = Vec::new();
+        for item in response
+            .get("output")
+            .and_then(|o| o.as_array())
+            .map(|a| a.as_slice())
+            .unwrap_or_default()
+        {
+            match item.get("type").and_then(|t| t.as_str()) {
+                Some("message") => {
+                    for part in item
+                        .get("content")
+                        .and_then(|c| c.as_array())
+                        .map(|a| a.as_slice())
+                        .unwrap_or_default()
+                    {
+                        if let Some(text) = part.get("text").and_then(|t| t.as_str()) {
+                            content.push_str(text);
+                        } else if let Some(refusal) = part.get("refusal").and_then(|r| r.as_str()) {
+                            content.push_str(refusal);
+                        }
+                    }
+                }
+                Some("function_call") => {
+                    let arguments = item
+                        .get("arguments")
+                        .and_then(|a| a.as_str())
+                        .and_then(|a| serde_json::from_str(a).ok())
+                        .unwrap_or_else(|| json!({}));
+                    calls.push(ToolCallRequest {
+                        id: item
+                            .get("call_id")
+                            .and_then(|c| c.as_str())
+                            .unwrap_or_default()
+                            .to_string(),
+                        name: item
+                            .get("name")
+                            .and_then(|n| n.as_str())
+                            .unwrap_or_default()
+                            .to_string(),
+                        arguments,
+                        raw: item.clone(),
+                    });
+                }
+                _ => {}
+            }
+        }
+        (content, calls)
+    }
+
+    fn parse_usage(response: &Value) -> Option<Usage> {
+        response.get("usage").map(|usage| Usage {
+            input_tokens: usage
+                .get("input_tokens")
+                .and_then(|v| v.as_i64())
+                .map(|v| v as i32),
+            output_tokens: usage
+                .get("output_tokens")
+                .and_then(|v| v.as_i64())
+                .map(|v| v as i32),
+            total_tokens: usage
+                .get("total_tokens")
+                .and_then(|v| v.as_i64())
+                .map(|v| v as i32),
+        })
+    }
+
+    /// Execute requested function calls and build the continuation body
+    /// (`previous_response_id` + `function_call_output` items).
+    async fn continuation_body(
+        &self,
+        request: &InvokeModelRequest,
+        previous_response_id: &str,
+        calls: Vec<ToolCallRequest>,
+        executed: &mut Vec<ExecutedToolCall>,
+        stream: bool,
+    ) -> Value {
+        let tools = request.tools.clone().unwrap_or_default();
+        let mut outputs = Vec::new();
+        for call in calls {
+            let call_id = call.id.clone();
+            let (message, record) = execute_tool_call(&tools, &call).await;
+            executed.push(record);
+            outputs.push(json!({
+                "type": "function_call_output",
+                "call_id": call_id,
+                "output": message.content,
+            }));
+        }
+        let mut body = self.build_responses_body(request, stream);
+        body["previous_response_id"] = json!(previous_response_id);
+        body["input"] = Value::Array(outputs);
+        body
+    }
+
+    pub async fn invoke(&self, request: &InvokeModelRequest) -> Result<ModelResponse, AppError> {
+        let mut executed: Vec<ExecutedToolCall> = Vec::new();
+        let mut body = self.build_responses_body(request, false);
+
+        for _cycle in 0..TOOL_CYCLES_LIMIT {
+            debug!("Responses API request for {}", body["model"]);
+            let response = self
+                .inner
+                .post("/responses")
+                .json(&body)
+                .send()
+                .await
+                .map_err(|e| AppError::Http(e.to_string()))?;
+            if !response.status().is_success() {
+                let status = response.status();
+                let text = response.text().await.unwrap_or_default();
+                return Err(self.inner.api_error(status, &text));
+            }
+            let payload: Value = response
+                .json()
+                .await
+                .map_err(|e| AppError::Http(e.to_string()))?;
+
+            let (content, calls) = Self::parse_output(&payload);
+            if calls.is_empty() {
+                return Ok(ModelResponse {
+                    content,
+                    model_id: request.model_id.clone(),
+                    usage: Self::parse_usage(&payload),
+                    finish_reason: payload
+                        .get("status")
+                        .and_then(|s| s.as_str())
+                        .map(String::from),
+                    tool_calls: vec![],
+                });
+            }
+            let response_id = payload
+                .get("id")
+                .and_then(|i| i.as_str())
+                .unwrap_or_default()
+                .to_string();
+            body = self
+                .continuation_body(request, &response_id, calls, &mut executed, false)
+                .await;
+        }
+        Err(AppError::Internal(
+            "Responses API tool call cycles limit exceeded".to_string(),
+        ))
+    }
+
+    pub async fn invoke_stream<F, C, E>(
+        &self,
+        request: &InvokeModelRequest,
+        callbacks: &StreamCallbacks<F, C, E>,
+    ) -> Result<Vec<ExecutedToolCall>, AppError>
+    where
+        F: Fn(String) -> Pin<Box<dyn Future<Output = ()> + Send>> + Send + Sync,
+        C: Fn(String) -> Pin<Box<dyn Future<Output = ()> + Send>> + Send + Sync,
+        E: Fn(AppError) -> Pin<Box<dyn Future<Output = ()> + Send>> + Send + Sync,
+    {
+        let mut executed: Vec<ExecutedToolCall> = Vec::new();
+        let mut full_response = String::new();
+        let mut body = self.build_responses_body(request, true);
+
+        for _cycle in 0..TOOL_CYCLES_LIMIT {
+            debug!("Responses API stream for {}", body["model"]);
+            let response = self
+                .inner
+                .post("/responses")
+                .json(&body)
+                .send()
+                .await
+                .map_err(|e| AppError::Http(e.to_string()))?;
+            if !response.status().is_success() {
+                let status = response.status();
+                let text = response.text().await.unwrap_or_default();
+                let error = self.inner.api_error(status, &text);
+                (callbacks.on_error)(error.clone()).await;
+                return Err(error);
+            }
+
+            let mut stream = response.bytes_stream();
+            let mut line_buffer = String::new();
+            let mut pending_calls: Vec<ToolCallRequest> = Vec::new();
+            let mut response_id = String::new();
+            let mut got_error: Option<AppError> = None;
+
+            'outer: while let Some(chunk) = stream.next().await {
+                let chunk = match chunk {
+                    Ok(chunk) => chunk,
+                    Err(e) => {
+                        let error = AppError::Http(format!("Stream error: {}", e));
+                        (callbacks.on_error)(error.clone()).await;
+                        return Err(error);
+                    }
+                };
+                line_buffer.push_str(&String::from_utf8_lossy(&chunk));
+
+                while let Some(newline_pos) = line_buffer.find('\n') {
+                    let line: String = line_buffer.drain(..=newline_pos).collect();
+                    let line = line.trim();
+                    if line.is_empty() || line.starts_with(':') || line.starts_with("event:") {
+                        continue;
+                    }
+                    let Some(data) = line.strip_prefix("data: ").or(Some(line)) else {
+                        continue;
+                    };
+                    if data == "[DONE]" {
+                        break 'outer;
+                    }
+                    let event: Value = match serde_json::from_str(data) {
+                        Ok(event) => event,
+                        Err(e) => {
+                            warn!("Responses stream: bad event: {} — {}", data, e);
+                            continue;
+                        }
+                    };
+
+                    match event.get("type").and_then(|t| t.as_str()) {
+                        Some("response.created") | Some("response.queued") => {
+                            if let Some(id) = event
+                                .get("response")
+                                .and_then(|r| r.get("id"))
+                                .and_then(|i| i.as_str())
+                            {
+                                response_id = id.to_string();
+                            }
+                        }
+                        Some("response.output_text.delta") => {
+                            if let Some(delta) = event.get("delta").and_then(|d| d.as_str()) {
+                                if !delta.is_empty() {
+                                    full_response.push_str(delta);
+                                    (callbacks.on_token)(delta.to_string()).await;
+                                }
+                            }
+                        }
+                        Some("response.output_item.done") => {
+                            let item = event.get("item").cloned().unwrap_or_default();
+                            if item.get("type").and_then(|t| t.as_str()) == Some("function_call") {
+                                let arguments = item
+                                    .get("arguments")
+                                    .and_then(|a| a.as_str())
+                                    .and_then(|a| serde_json::from_str(a).ok())
+                                    .unwrap_or_else(|| json!({}));
+                                pending_calls.push(ToolCallRequest {
+                                    id: item
+                                        .get("call_id")
+                                        .and_then(|c| c.as_str())
+                                        .unwrap_or_default()
+                                        .to_string(),
+                                    name: item
+                                        .get("name")
+                                        .and_then(|n| n.as_str())
+                                        .unwrap_or_default()
+                                        .to_string(),
+                                    arguments,
+                                    raw: item,
+                                });
+                            }
+                        }
+                        Some("response.completed") | Some("response.incomplete") => {
+                            if let Some(id) = event
+                                .get("response")
+                                .and_then(|r| r.get("id"))
+                                .and_then(|i| i.as_str())
+                            {
+                                response_id = id.to_string();
+                            }
+                            break 'outer;
+                        }
+                        Some("error") => {
+                            let message = event
+                                .get("message")
+                                .and_then(|m| m.as_str())
+                                .unwrap_or("Responses stream error")
+                                .to_string();
+                            got_error = Some(AppError::Internal(message));
+                            break 'outer;
+                        }
+                        _ => {}
+                    }
+                }
+            }
+
+            if let Some(error) = got_error {
+                (callbacks.on_error)(error.clone()).await;
+                return Err(error);
+            }
+            if pending_calls.is_empty() {
+                (callbacks.on_complete)(full_response).await;
+                return Ok(executed);
+            }
+            body = self
+                .continuation_body(request, &response_id, pending_calls, &mut executed, true)
+                .await;
+        }
+
+        let error = AppError::Internal("Responses API tool call cycles limit exceeded".to_string());
+        (callbacks.on_error)(error.clone()).await;
+        Err(error)
+    }
+
+    /// Cancel an in-flight background response (`POST /responses/{id}/cancel`).
+    pub async fn cancel(&self, response_id: &str) -> Result<(), AppError> {
+        let response = self
+            .inner
+            .post(&format!("/responses/{}/cancel", response_id))
+            .send()
+            .await
+            .map_err(|e| AppError::Http(e.to_string()))?;
+        if !response.status().is_success() {
+            let status = response.status();
+            let text = response.text().await.unwrap_or_default();
+            return Err(self.inner.api_error(status, &text));
+        }
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::services::ai::ModelMessage;
+
+    fn request(model: &str) -> InvokeModelRequest {
+        InvokeModelRequest {
+            model_id: model.to_string(),
+            messages: vec![ModelMessage::text(MessageRole::User, "hi")],
+            temperature: Some(0.5),
+            max_tokens: Some(100),
+            top_p: None,
+            system_prompt: Some("be brief".to_string()),
+            tools: None,
+        }
+    }
+
+    #[test]
+    fn detects_responses_models() {
+        for id in [
+            "gpt-5",
+            "gpt-5-mini",
+            "gpt-4.1-nano",
+            "gpt-4o",
+            "o3-mini",
+            "o4-mini",
+        ] {
+            assert!(uses_responses_api(id), "{}", id);
+        }
+        for id in ["gpt-3.5-turbo", "deepseek-chat", "llama3"] {
+            assert!(!uses_responses_api(id), "{}", id);
+        }
+    }
+
+    #[test]
+    fn builds_responses_body() {
+        let protocol = OpenAIResponsesProtocol::new(OpenAIProtocol::new(
+            "https://api.openai.com/v1",
+            None,
+            None,
+            "OpenAI",
+        ));
+        let body = protocol.build_responses_body(&request("gpt-4.1"), false);
+        assert_eq!(body["model"], "gpt-4.1");
+        assert_eq!(body["instructions"], "be brief");
+        assert_eq!(body["max_output_tokens"], 100);
+        assert_eq!(body["temperature"], 0.5);
+        assert_eq!(body["input"][0]["role"], "user");
+        assert!(body.get("stream").is_none());
+    }
+
+    #[test]
+    fn reasoning_models_drop_sampling_and_get_effort() {
+        let protocol = OpenAIResponsesProtocol::new(OpenAIProtocol::new(
+            "https://api.openai.com/v1",
+            None,
+            None,
+            "OpenAI",
+        ));
+        let body = protocol.build_responses_body(&request("gpt-5-mini"), true);
+        assert!(body.get("temperature").is_none());
+        assert_eq!(body["reasoning"]["effort"], "minimal");
+        assert_eq!(body["stream"], true);
+    }
+
+    #[test]
+    fn parses_output_items() {
+        let payload = serde_json::json!({
+            "output": [
+                { "type": "message", "content": [ { "type": "output_text", "text": "Hello" } ] },
+                { "type": "function_call", "call_id": "c1", "name": "web_search",
+                  "arguments": "{\"query\":\"rust\"}" }
+            ],
+            "usage": { "input_tokens": 5, "output_tokens": 2, "total_tokens": 7 }
+        });
+        let (content, calls) = OpenAIResponsesProtocol::parse_output(&payload);
+        assert_eq!(content, "Hello");
+        assert_eq!(calls.len(), 1);
+        assert_eq!(calls[0].name, "web_search");
+        assert_eq!(calls[0].arguments["query"], "rust");
+    }
+}

--- a/api-rust/src/services/openai_responses.rs
+++ b/api-rust/src/services/openai_responses.rs
@@ -309,6 +309,7 @@ impl OpenAIResponsesProtocol {
                         .and_then(|s| s.as_str())
                         .map(String::from),
                     tool_calls: vec![],
+                    audios: vec![],
                 });
             }
             let response_id = payload
@@ -519,6 +520,7 @@ mod tests {
             native_tools: vec![],
             thinking: None,
             thinking_budget: None,
+            voice: None,
         }
     }
 

--- a/api-rust/src/services/openai_responses.rs
+++ b/api-rust/src/services/openai_responses.rs
@@ -101,6 +101,30 @@ impl OpenAIResponsesProtocol {
                     MessageRole::System => "developer",
                     MessageRole::Tool => unreachable!(),
                 };
+                // A turn carrying inline files serializes its content as an
+                // items array: textual files as input_text, PDFs as
+                // input_file (files are user-provided context).
+                if !m.files.is_empty() {
+                    let mut parts = Vec::new();
+                    if !m.content.is_empty() {
+                        parts.push(json!({ "type": "input_text", "text": m.content }));
+                    }
+                    for file in &m.files {
+                        if let Some(text) = &file.text {
+                            parts.push(json!({
+                                "type": "input_text",
+                                "text": format!("File \"{}\":\n\n{}", file.name, text),
+                            }));
+                        } else if let Some(base64) = &file.base64 {
+                            parts.push(json!({
+                                "type": "input_file",
+                                "filename": file.name,
+                                "file_data": format!("data:{};base64,{}", file.mime_type, base64),
+                            }));
+                        }
+                    }
+                    return json!({ "role": "user", "content": parts });
+                }
                 json!({ "role": role, "content": m.content })
             })
             .collect();
@@ -610,6 +634,38 @@ mod tests {
         // gpt-5 + web_search cannot use "minimal" → bumped to "medium"
         assert_eq!(body["reasoning"]["effort"], "medium");
         assert_eq!(body["reasoning"]["summary"], "auto");
+    }
+
+    #[test]
+    fn inline_files_serialize_input_file_items() {
+        let protocol = OpenAIResponsesProtocol::new(OpenAIProtocol::new(
+            "https://api.openai.com/v1",
+            None,
+            None,
+            "OpenAI",
+        ));
+        let mut req = request("gpt-4.1");
+        req.messages = vec![crate::services::ai::ModelMessage {
+            role: MessageRole::User,
+            content: "read this".to_string(),
+            timestamp: None,
+            tool_calls: None,
+            tool_call_id: None,
+            audio: None,
+            files: vec![crate::services::ai::ModelFile {
+                s3_key: "c/m/doc.pdf".to_string(),
+                name: "doc.pdf".to_string(),
+                mime_type: "application/pdf".to_string(),
+                text: None,
+                base64: Some("QUJD".to_string()),
+            }],
+        }];
+        let body = protocol.build_responses_body(&req, false);
+        let content = &body["input"][0]["content"];
+        assert_eq!(content[0]["type"], "input_text");
+        assert_eq!(content[1]["type"], "input_file");
+        assert_eq!(content[1]["filename"], "doc.pdf");
+        assert_eq!(content[1]["file_data"], "data:application/pdf;base64,QUJD");
     }
 
     #[test]

--- a/api-rust/src/services/openai_responses.rs
+++ b/api-rust/src/services/openai_responses.rs
@@ -38,6 +38,17 @@ const REASONING_MAX_TOKEN_BUDGET: i32 = 16000;
 /// NATIVE_WEB_SEARCH_TOOL_NAME).
 pub const NATIVE_WEB_SEARCH_TOOL_NAME: &str = "web_search";
 
+/// Clamp a reasoning effort to what the model accepts. "pro" reasoning
+/// models (gpt-5-pro, gpt-5.5-pro, …) reject "minimal"/"low" — their
+/// minimum is "medium" (they support medium/high/xhigh).
+fn clamp_reasoning_effort<'a>(model: &str, effort: &'a str) -> &'a str {
+    if model.contains("pro") && matches!(effort, "minimal" | "low") {
+        "medium"
+    } else {
+        effort
+    }
+}
+
 /// Build an ExecutedToolCall record from a native `web_search_call` output
 /// item (Node records the query into metadata.toolCalls for display).
 fn native_web_search_record(item: &Value) -> ExecutedToolCall {
@@ -172,8 +183,7 @@ impl OpenAIResponsesProtocol {
         }
 
         // Reasoning ("thinking") effort mapped from the token budget
-        // (Node's formatResponsesRequest). gpt-5 with native web_search
-        // cannot use the "minimal" effort.
+        // (Node's formatResponsesRequest).
         if request.thinking.unwrap_or(false) {
             let budget = request
                 .thinking_budget
@@ -189,13 +199,17 @@ impl OpenAIResponsesProtocol {
             } else {
                 "high"
             };
+            // gpt-5 with native web_search cannot use "minimal".
             if model.starts_with("gpt-5") && has_native_web_search && effort == "minimal" {
                 effort = "medium";
             }
-            body["reasoning"] = json!({ "effort": effort, "summary": "auto" });
+            body["reasoning"] =
+                json!({ "effort": clamp_reasoning_effort(&model, effort), "summary": "auto" });
         } else if model.starts_with("gpt-5") {
-            // Reasoning-cancellation default for gpt-5 family (Node parity).
-            body["reasoning"] = json!({ "effort": "minimal" });
+            // Reasoning-cancellation default for the gpt-5 family (Node
+            // parity): minimal where supported, clamped up for models that
+            // reject it (e.g. gpt-5-pro / gpt-5.5-pro require medium+).
+            body["reasoning"] = json!({ "effort": clamp_reasoning_effort(&model, "minimal") });
         }
         body
     }
@@ -594,6 +608,10 @@ mod tests {
         assert!(body.get("temperature").is_none());
         assert_eq!(body["reasoning"]["effort"], "minimal");
         assert_eq!(body["stream"], true);
+
+        // "pro" reasoning models reject minimal — clamp up to medium.
+        let pro = protocol.build_responses_body(&request("gpt-5.5-pro"), false);
+        assert_eq!(pro["reasoning"]["effort"], "medium");
     }
 
     #[test]

--- a/api-rust/src/services/openai_responses.rs
+++ b/api-rust/src/services/openai_responses.rs
@@ -29,6 +29,48 @@ pub const RESPONSES_MODEL_PREFIXES: &[&str] =
 /// Reasoning models reject sampling params (Node deletes temperature).
 const NO_SAMPLING_PREFIXES: &[&str] = &["o1", "o3", "o4", "gpt-4o", "gpt-5"];
 
+/// Reasoning token-budget bounds (Node's ai.reasoningMinTokenBudget /
+/// reasoningMaxTokenBudget). The budget maps to an effort level.
+const REASONING_MIN_TOKEN_BUDGET: i32 = 1024;
+const REASONING_MAX_TOKEN_BUDGET: i32 = 16000;
+
+/// Native web-search tool-call name in Responses output (Node's
+/// NATIVE_WEB_SEARCH_TOOL_NAME).
+pub const NATIVE_WEB_SEARCH_TOOL_NAME: &str = "web_search";
+
+/// Build an ExecutedToolCall record from a native `web_search_call` output
+/// item (Node records the query into metadata.toolCalls for display).
+fn native_web_search_record(item: &Value) -> ExecutedToolCall {
+    let action = item.get("action");
+    let query = action
+        .and_then(|a| a.get("queries"))
+        .and_then(|q| q.as_array())
+        .map(|arr| {
+            arr.iter()
+                .filter_map(|q| q.as_str())
+                .collect::<Vec<_>>()
+                .join("\n\n")
+        })
+        .filter(|s| !s.is_empty())
+        .or_else(|| {
+            action
+                .and_then(|a| a.get("query"))
+                .and_then(|q| q.as_str())
+                .map(String::from)
+        })
+        .unwrap_or_default();
+    ExecutedToolCall {
+        id: item
+            .get("id")
+            .and_then(|i| i.as_str())
+            .unwrap_or_default()
+            .to_string(),
+        name: NATIVE_WEB_SEARCH_TOOL_NAME.to_string(),
+        args_json: json!({ "query": query }).to_string(),
+        content: String::new(),
+    }
+}
+
 pub fn uses_responses_api(model_id: &str) -> bool {
     RESPONSES_MODEL_PREFIXES.iter().any(|p| {
         model_id == *p || model_id.starts_with(&format!("{}-", p)) || model_id.starts_with(*p)
@@ -79,31 +121,65 @@ impl OpenAIResponsesProtocol {
                 body["temperature"] = json!(temperature);
             }
         }
-        if model.starts_with("gpt-5") {
-            body["reasoning"] = json!({ "effort": "minimal" });
+
+        // Native provider tool blocks (web_search / code_interpreter) plus
+        // any local function tools (MCP, etc.).
+        let mut tools: Vec<Value> = Vec::new();
+        let has_native_web_search = request.native_tools.iter().any(|t| t == "web_search");
+        if has_native_web_search {
+            tools.push(json!({ "type": "web_search", "search_context_size": "low" }));
         }
-        if let Some(tools) = request.tools.as_deref().filter(|t| !t.is_empty()) {
-            body["tools"] = Value::Array(
-                tools
-                    .iter()
-                    .map(|tool| {
-                        json!({
-                            "type": "function",
-                            "name": tool.spec.name,
-                            "description": tool.spec.description,
-                            "parameters": tool.spec.input_schema,
-                            "strict": false,
-                        })
-                    })
-                    .collect(),
-            );
+        if request.native_tools.iter().any(|t| t == "code_interpreter") {
+            tools.push(json!({ "type": "code_interpreter", "container": { "type": "auto" } }));
+        }
+        if let Some(function_tools) = request.tools.as_deref() {
+            for tool in function_tools {
+                tools.push(json!({
+                    "type": "function",
+                    "name": tool.spec.name,
+                    "description": tool.spec.description,
+                    "parameters": tool.spec.input_schema,
+                    "strict": false,
+                }));
+            }
+        }
+        if !tools.is_empty() {
+            body["tools"] = Value::Array(tools);
+        }
+
+        // Reasoning ("thinking") effort mapped from the token budget
+        // (Node's formatResponsesRequest). gpt-5 with native web_search
+        // cannot use the "minimal" effort.
+        if request.thinking.unwrap_or(false) {
+            let budget = request
+                .thinking_budget
+                .unwrap_or(REASONING_MIN_TOKEN_BUDGET)
+                .max(0);
+            let max_budget = REASONING_MAX_TOKEN_BUDGET as f64;
+            let mut effort = if (budget as f64) < max_budget * 0.1 {
+                "minimal"
+            } else if (budget as f64) < max_budget * 0.25 {
+                "low"
+            } else if (budget as f64) < max_budget * 0.75 {
+                "medium"
+            } else {
+                "high"
+            };
+            if model.starts_with("gpt-5") && has_native_web_search && effort == "minimal" {
+                effort = "medium";
+            }
+            body["reasoning"] = json!({ "effort": effort, "summary": "auto" });
+        } else if model.starts_with("gpt-5") {
+            // Reasoning-cancellation default for gpt-5 family (Node parity).
+            body["reasoning"] = json!({ "effort": "minimal" });
         }
         body
     }
 
-    fn parse_output(response: &Value) -> (String, Vec<ToolCallRequest>) {
+    fn parse_output(response: &Value) -> (String, Vec<ToolCallRequest>, Vec<ExecutedToolCall>) {
         let mut content = String::new();
         let mut calls = Vec::new();
+        let mut executed = Vec::new();
         for item in response
             .get("output")
             .and_then(|o| o.as_array())
@@ -111,6 +187,7 @@ impl OpenAIResponsesProtocol {
             .unwrap_or_default()
         {
             match item.get("type").and_then(|t| t.as_str()) {
+                Some("web_search_call") => executed.push(native_web_search_record(item)),
                 Some("message") => {
                     for part in item
                         .get("content")
@@ -149,7 +226,7 @@ impl OpenAIResponsesProtocol {
                 _ => {}
             }
         }
-        (content, calls)
+        (content, calls, executed)
     }
 
     fn parse_usage(response: &Value) -> Option<Usage> {
@@ -220,7 +297,8 @@ impl OpenAIResponsesProtocol {
                 .await
                 .map_err(|e| AppError::Http(e.to_string()))?;
 
-            let (content, calls) = Self::parse_output(&payload);
+            let (content, calls, native_executed) = Self::parse_output(&payload);
+            executed.extend(native_executed);
             if calls.is_empty() {
                 return Ok(ModelResponse {
                     content,
@@ -335,26 +413,34 @@ impl OpenAIResponsesProtocol {
                         }
                         Some("response.output_item.done") => {
                             let item = event.get("item").cloned().unwrap_or_default();
-                            if item.get("type").and_then(|t| t.as_str()) == Some("function_call") {
-                                let arguments = item
-                                    .get("arguments")
-                                    .and_then(|a| a.as_str())
-                                    .and_then(|a| serde_json::from_str(a).ok())
-                                    .unwrap_or_else(|| json!({}));
-                                pending_calls.push(ToolCallRequest {
-                                    id: item
-                                        .get("call_id")
-                                        .and_then(|c| c.as_str())
-                                        .unwrap_or_default()
-                                        .to_string(),
-                                    name: item
-                                        .get("name")
-                                        .and_then(|n| n.as_str())
-                                        .unwrap_or_default()
-                                        .to_string(),
-                                    arguments,
-                                    raw: item,
-                                });
+                            match item.get("type").and_then(|t| t.as_str()) {
+                                Some("function_call") => {
+                                    let arguments = item
+                                        .get("arguments")
+                                        .and_then(|a| a.as_str())
+                                        .and_then(|a| serde_json::from_str(a).ok())
+                                        .unwrap_or_else(|| json!({}));
+                                    pending_calls.push(ToolCallRequest {
+                                        id: item
+                                            .get("call_id")
+                                            .and_then(|c| c.as_str())
+                                            .unwrap_or_default()
+                                            .to_string(),
+                                        name: item
+                                            .get("name")
+                                            .and_then(|n| n.as_str())
+                                            .unwrap_or_default()
+                                            .to_string(),
+                                        arguments,
+                                        raw: item,
+                                    });
+                                }
+                                // Native web_search executes server-side; record
+                                // it for the assistant message's tool badges.
+                                Some("web_search_call") => {
+                                    executed.push(native_web_search_record(&item));
+                                }
+                                _ => {}
                             }
                         }
                         Some("response.completed") | Some("response.incomplete") => {
@@ -430,6 +516,9 @@ mod tests {
             top_p: None,
             system_prompt: Some("be brief".to_string()),
             tools: None,
+            native_tools: vec![],
+            thinking: None,
+            thinking_budget: None,
         }
     }
 
@@ -491,10 +580,50 @@ mod tests {
             ],
             "usage": { "input_tokens": 5, "output_tokens": 2, "total_tokens": 7 }
         });
-        let (content, calls) = OpenAIResponsesProtocol::parse_output(&payload);
+        let (content, calls, _executed) = OpenAIResponsesProtocol::parse_output(&payload);
         assert_eq!(content, "Hello");
         assert_eq!(calls.len(), 1);
         assert_eq!(calls[0].name, "web_search");
         assert_eq!(calls[0].arguments["query"], "rust");
+    }
+
+    #[test]
+    fn serializes_native_tools_and_reasoning() {
+        let protocol = OpenAIResponsesProtocol::new(OpenAIProtocol::new(
+            "https://api.openai.com/v1",
+            None,
+            None,
+            "OpenAI",
+        ));
+        let mut req = request("gpt-5");
+        req.native_tools = vec!["web_search".to_string(), "code_interpreter".to_string()];
+        req.thinking = Some(true);
+        req.thinking_budget = Some(1000); // < 10% of max → would be minimal, bumped to medium
+        let body = protocol.build_responses_body(&req, true);
+        let tools = body["tools"].as_array().unwrap();
+        assert_eq!(tools[0]["type"], "web_search");
+        assert_eq!(tools[0]["search_context_size"], "low");
+        assert_eq!(tools[1]["type"], "code_interpreter");
+        assert_eq!(tools[1]["container"]["type"], "auto");
+        // gpt-5 + web_search cannot use "minimal" → bumped to "medium"
+        assert_eq!(body["reasoning"]["effort"], "medium");
+        assert_eq!(body["reasoning"]["summary"], "auto");
+    }
+
+    #[test]
+    fn parses_native_web_search_call() {
+        let payload = serde_json::json!({
+            "output": [
+                { "type": "web_search_call", "id": "ws_1",
+                  "action": { "type": "search", "query": "rust async" } },
+                { "type": "message", "content": [ { "type": "output_text", "text": "Done" } ] }
+            ]
+        });
+        let (content, calls, executed) = OpenAIResponsesProtocol::parse_output(&payload);
+        assert_eq!(content, "Done");
+        assert!(calls.is_empty());
+        assert_eq!(executed.len(), 1);
+        assert_eq!(executed[0].name, "web_search");
+        assert!(executed[0].args_json.contains("rust async"));
     }
 }

--- a/api-rust/src/services/realtime.rs
+++ b/api-rust/src/services/realtime.rs
@@ -1,0 +1,330 @@
+//! Realtime voice sessions (Node's realtime.service): mint an OpenAI
+//! ephemeral WebRTC session, or fall back to a server-side WebSocket
+//! proxy (`/realtime/proxy` on the subscriptions server) used for
+//! Yandex Speech Realtime and as the OpenAI fallback.
+
+use futures_util::{SinkExt, StreamExt};
+use serde::{Deserialize, Serialize};
+use tracing::{info, warn};
+
+use crate::config::AppConfig;
+use crate::models::{Chat, Model};
+use crate::utils::errors::AppError;
+
+pub const OPENAI_API_URL: &str = "https://api.openai.com/v1";
+pub const OPENAI_REALTIME_VOICES: &[&str] = &[
+    "marin", "cedar", "alloy", "ash", "ballad", "coral", "echo", "sage", "shimmer", "verse",
+];
+pub const OPENAI_REALTIME_DEFAULT_VOICE: &str = "shimmer";
+pub const YANDEX_REALTIME_VOICES: &[&str] = &[
+    "alena", "marina", "jane", "omazh", "filipp", "ermil", "zahar", "madirus",
+];
+pub const YANDEX_REALTIME_DEFAULT_VOICE: &str = "marina";
+pub const YANDEX_REALTIME_API_URL: &str = "wss://ai.api.cloud.yandex.net/v1/realtime";
+pub const REALTIME_PROXY_PATH: &str = "/realtime/proxy";
+pub const OPENAI_REALTIME_TRANSCRIPTION_MODEL: &str = "whisper-1";
+
+#[derive(Debug, Clone, Serialize, Deserialize, async_graphql::SimpleObject)]
+#[graphql(name = "RealtimeSessionResponse")]
+#[serde(rename_all = "camelCase")]
+pub struct RealtimeSessionResponse {
+    pub transport: String,
+    pub model: String,
+    pub client_secret: Option<String>,
+    pub sdp_url: Option<String>,
+    pub ws_url: Option<String>,
+}
+
+/// Pick the assistant voice: the requested one when the provider
+/// supports it, else the provider default (Node parity; api-rust has
+/// no per-chat voice column yet, so `requested` is currently None).
+pub fn pick_voice(model: &Model, requested: Option<&str>) -> String {
+    let (voices, default) = if model.api_provider == "YANDEX_AI" {
+        (YANDEX_REALTIME_VOICES, YANDEX_REALTIME_DEFAULT_VOICE)
+    } else {
+        (OPENAI_REALTIME_VOICES, OPENAI_REALTIME_DEFAULT_VOICE)
+    };
+    requested
+        .filter(|v| voices.contains(v))
+        .unwrap_or(default)
+        .to_string()
+}
+
+/// Mint an OpenAI ephemeral client secret for a WebRTC realtime session.
+pub async fn create_openai_ephemeral_session(
+    config: &AppConfig,
+    model: &Model,
+    voice: &str,
+) -> Result<RealtimeSessionResponse, AppError> {
+    let api_key = config
+        .openai_api_key
+        .as_deref()
+        .ok_or_else(|| AppError::Validation("OpenAI API key not configured".to_string()))?;
+    let base = OPENAI_API_URL;
+
+    let body = serde_json::json!({
+        "session": {
+            "type": "realtime",
+            "model": model.model_id,
+            "audio": {
+                "input": { "transcription": { "model": OPENAI_REALTIME_TRANSCRIPTION_MODEL } },
+                "output": { "voice": voice },
+            },
+        }
+    });
+    let response = reqwest::Client::new()
+        .post(format!("{}/realtime/client_secrets", base))
+        .bearer_auth(api_key)
+        .json(&body)
+        .send()
+        .await
+        .map_err(|e| AppError::Internal(format!("Realtime session request failed: {}", e)))?;
+    if !response.status().is_success() {
+        let status = response.status();
+        let text = response.text().await.unwrap_or_default();
+        return Err(AppError::Internal(format!(
+            "Realtime session request failed ({}): {}",
+            status,
+            text.chars().take(300).collect::<String>()
+        )));
+    }
+    let session: serde_json::Value = response
+        .json()
+        .await
+        .map_err(|e| AppError::Internal(format!("Realtime session response: {}", e)))?;
+    let client_secret = session
+        .get("value")
+        .and_then(|v| v.as_str())
+        .or_else(|| {
+            session
+                .get("client_secret")
+                .and_then(|c| c.get("value"))
+                .and_then(|v| v.as_str())
+        })
+        .ok_or_else(|| AppError::Internal("Realtime session response without value".to_string()))?
+        .to_string();
+
+    Ok(RealtimeSessionResponse {
+        transport: "webrtc".to_string(),
+        model: model.model_id.clone(),
+        client_secret: Some(client_secret),
+        sdp_url: Some(format!("{}/realtime/calls?model={}", base, model.model_id)),
+        ws_url: None,
+    })
+}
+
+/// Upstream WS target for the proxy path.
+pub struct UpstreamTarget {
+    pub url: String,
+    pub headers: Vec<(String, String)>,
+    /// whisper transcription only applies to OpenAI upstreams
+    pub with_transcription: bool,
+}
+
+pub fn upstream_target(config: &AppConfig, model: &Model) -> Result<UpstreamTarget, AppError> {
+    if model.api_provider == "YANDEX_AI" {
+        let key = config
+            .yandex_api_key
+            .as_deref()
+            .ok_or_else(|| AppError::Validation("Yandex API key not configured".to_string()))?;
+        let folder = config.yandex_folder_id.clone().unwrap_or_default();
+        let model_uri = model.model_id.replace("{folder}", &folder);
+        let auth = if key.starts_with("t1.") {
+            format!("Bearer {}", key)
+        } else {
+            format!("Api-Key {}", key)
+        };
+        Ok(UpstreamTarget {
+            url: format!("{}?model={}", YANDEX_REALTIME_API_URL, model_uri),
+            headers: vec![
+                ("Authorization".to_string(), auth),
+                ("OpenAI-Project".to_string(), folder.clone()),
+                ("x-folder-id".to_string(), folder),
+            ],
+            with_transcription: false,
+        })
+    } else {
+        let key = config
+            .openai_api_key
+            .as_deref()
+            .ok_or_else(|| AppError::Validation("OpenAI API key not configured".to_string()))?;
+        let ws_base = OPENAI_API_URL.replacen("http", "ws", 1);
+        Ok(UpstreamTarget {
+            url: format!("{}/realtime?model={}", ws_base, model.model_id),
+            headers: vec![("Authorization".to_string(), format!("Bearer {}", key))],
+            with_transcription: true,
+        })
+    }
+}
+
+fn session_update(chat: &Chat, voice: &str, with_transcription: bool) -> serde_json::Value {
+    let mut input = serde_json::json!({
+        "format": { "type": "audio/pcm", "rate": 24000 },
+        "turn_detection": { "type": "server_vad", "silence_duration_ms": 800, "threshold": 0.5 },
+    });
+    if with_transcription {
+        input["transcription"] =
+            serde_json::json!({ "model": OPENAI_REALTIME_TRANSCRIPTION_MODEL });
+    }
+    let mut session = serde_json::json!({
+        "type": "realtime",
+        "output_modalities": ["audio"],
+        "audio": {
+            "input": input,
+            "output": {
+                "voice": voice,
+                "format": { "type": "audio/pcm", "rate": 24000 },
+                "speed": 1,
+            },
+        },
+    });
+    if let Some(prompt) = chat.system_prompt.as_deref().filter(|p| !p.is_empty()) {
+        session["instructions"] = serde_json::json!(prompt);
+    }
+    serde_json::json!({ "type": "session.update", "session": session })
+}
+
+/// Relay a client WebSocket to the provider's realtime endpoint. Client
+/// messages are buffered until the upstream reports `session.created`
+/// (3s cap), then a `session.update` with our audio config is injected
+/// before the buffer flushes. Frames are always forwarded as text —
+/// providers drop binary frames (Node parity).
+pub async fn run_proxy(
+    client_ws: warp::ws::WebSocket,
+    config: AppConfig,
+    chat: Chat,
+    model: Model,
+) {
+    use tokio_tungstenite::tungstenite::client::IntoClientRequest;
+    use tokio_tungstenite::tungstenite::Message as TMessage;
+    use warp::ws::Message as WMessage;
+
+    let target = match upstream_target(&config, &model) {
+        Ok(target) => target,
+        Err(e) => {
+            warn!("Realtime proxy: no upstream target: {}", e);
+            return;
+        }
+    };
+    let voice = pick_voice(&model, None);
+
+    let mut request = match target.url.clone().into_client_request() {
+        Ok(request) => request,
+        Err(e) => {
+            warn!("Realtime proxy: bad upstream URL: {}", e);
+            return;
+        }
+    };
+    for (name, value) in &target.headers {
+        if let (Ok(name), Ok(value)) = (
+            name.parse::<tokio_tungstenite::tungstenite::http::header::HeaderName>(),
+            value.parse(),
+        ) {
+            request.headers_mut().insert(name, value);
+        }
+    }
+
+    let (upstream, _) = match tokio_tungstenite::connect_async(request).await {
+        Ok(pair) => pair,
+        Err(e) => {
+            warn!("Realtime proxy: upstream connect failed: {}", e);
+            return;
+        }
+    };
+    info!("Realtime proxy connected to {}", target.url);
+
+    let (mut up_tx, mut up_rx) = upstream.split();
+    let (mut client_tx, mut client_rx) = client_ws.split();
+
+    let mut buffered: Vec<String> = Vec::new();
+    let mut session_ready = false;
+    let update = session_update(&chat, &voice, target.with_transcription);
+    let deadline = tokio::time::Instant::now() + std::time::Duration::from_secs(3);
+
+    // Phase 1: wait for session.created (or timeout), buffering client input
+    while !session_ready {
+        tokio::select! {
+            up_message = up_rx.next() => {
+                match up_message {
+                    Some(Ok(TMessage::Text(text))) => {
+                        let created = serde_json::from_str::<serde_json::Value>(&text)
+                            .ok()
+                            .and_then(|v| v.get("type").and_then(|t| t.as_str()).map(String::from))
+                            .is_some_and(|t| t == "session.created");
+                        let _ = client_tx.send(WMessage::text(text)).await;
+                        if created {
+                            session_ready = true;
+                        }
+                    }
+                    Some(Ok(_)) => {}
+                    _ => return,
+                }
+            }
+            client_message = client_rx.next() => {
+                match client_message {
+                    Some(Ok(message)) if message.is_text() => {
+                        buffered.push(message.to_str().unwrap_or_default().to_string());
+                    }
+                    Some(Ok(_)) => {}
+                    _ => return,
+                }
+            }
+            _ = tokio::time::sleep_until(deadline) => { session_ready = true; }
+        }
+    }
+
+    let _ = up_tx.send(TMessage::Text(update.to_string())).await;
+    for message in buffered.drain(..) {
+        let _ = up_tx.send(TMessage::Text(message)).await;
+    }
+
+    // Phase 2: bidirectional relay (text frames only)
+    let client_to_up = async {
+        while let Some(Ok(message)) = client_rx.next().await {
+            if message.is_text() {
+                if up_tx
+                    .send(TMessage::Text(
+                        message.to_str().unwrap_or_default().to_string(),
+                    ))
+                    .await
+                    .is_err()
+                {
+                    break;
+                }
+            } else if message.is_close() {
+                let _ = up_tx.send(TMessage::Close(None)).await;
+                break;
+            }
+        }
+    };
+    let up_to_client = async {
+        while let Some(Ok(message)) = up_rx.next().await {
+            match message {
+                TMessage::Text(text) => {
+                    if client_tx.send(WMessage::text(text)).await.is_err() {
+                        break;
+                    }
+                }
+                TMessage::Binary(bytes) => {
+                    // forward as text — clients expect JSON events
+                    if let Ok(text) = String::from_utf8(bytes) {
+                        if client_tx.send(WMessage::text(text)).await.is_err() {
+                            break;
+                        }
+                    }
+                }
+                TMessage::Close(_) => {
+                    let _ = client_tx.send(WMessage::close()).await;
+                    break;
+                }
+                _ => {}
+            }
+        }
+    };
+
+    tokio::select! {
+        _ = client_to_up => {},
+        _ = up_to_client => {},
+    }
+    info!("Realtime proxy session closed for chat {}", chat.id);
+}

--- a/api-rust/src/services/tools.rs
+++ b/api-rust/src/services/tools.rs
@@ -41,6 +41,7 @@ pub async fn execute_tool_call(
         timestamp: None,
         tool_calls: None,
         tool_call_id: Some(call.id.clone()),
+        audio: None,
     };
     (message, executed)
 }

--- a/api-rust/src/services/tools.rs
+++ b/api-rust/src/services/tools.rs
@@ -42,6 +42,7 @@ pub async fn execute_tool_call(
         tool_calls: None,
         tool_call_id: Some(call.id.clone()),
         audio: None,
+        files: vec![],
     };
     (message, executed)
 }

--- a/api-rust/src/services/yandex.rs
+++ b/api-rust/src/services/yandex.rs
@@ -165,6 +165,7 @@ impl AIProviderService for YandexService {
                 native_tools: vec![],
                 thinking: None,
                 thinking_budget: None,
+                voice: None,
             };
 
             match self.invoke_model(test_request).await {

--- a/api-rust/src/services/yandex.rs
+++ b/api-rust/src/services/yandex.rs
@@ -134,6 +134,9 @@ impl AIProviderService for YandexService {
                     streaming: true,
                     image_input: false,
                     max_input_tokens: None,
+                    // Yandex models carry per-model features in the Node
+                    // config; none of these hardcoded chat models declare any.
+                    features: Vec::new(),
                 },
             );
         }

--- a/api-rust/src/services/yandex.rs
+++ b/api-rust/src/services/yandex.rs
@@ -162,6 +162,9 @@ impl AIProviderService for YandexService {
                 top_p: None,
                 system_prompt: None,
                 tools: None,
+                native_tools: vec![],
+                thinking: None,
+                thinking_budget: None,
             };
 
             match self.invoke_model(test_request).await {

--- a/api-rust/src/utils/jwt.rs
+++ b/api-rust/src/utils/jwt.rs
@@ -96,6 +96,50 @@ pub fn verify_reset_token(token: &str, secret: &str) -> Result<ResetClaims, Stri
     Ok(claims)
 }
 
+/// Short-lived token authorizing a realtime proxy connection.
+#[derive(Debug, Serialize, Deserialize)]
+pub struct RealtimeClaims {
+    pub user_id: String,
+    pub chat_id: String,
+    pub purpose: String,
+    pub exp: i64,
+}
+
+pub fn create_realtime_token(
+    user_id: &str,
+    chat_id: &str,
+    secret: &str,
+) -> Result<String, jsonwebtoken::errors::Error> {
+    let claims = RealtimeClaims {
+        user_id: user_id.to_string(),
+        chat_id: chat_id.to_string(),
+        purpose: "realtime".to_string(),
+        exp: (Utc::now() + Duration::minutes(10)).timestamp(),
+    };
+    encode(
+        &Header::default(),
+        &claims,
+        &EncodingKey::from_secret(secret.as_ref()),
+    )
+}
+
+pub fn verify_realtime_token(token: &str, secret: &str) -> Result<RealtimeClaims, String> {
+    let mut validation = Validation::new(Algorithm::HS256);
+    validation.validate_exp = true;
+    validation.set_required_spec_claims(&["exp"]);
+    let claims = decode::<RealtimeClaims>(
+        token,
+        &DecodingKey::from_secret(secret.as_ref()),
+        &validation,
+    )
+    .map(|d| d.claims)
+    .map_err(|e| e.to_string())?;
+    if claims.purpose != "realtime" {
+        return Err("Invalid token purpose".to_string());
+    }
+    Ok(claims)
+}
+
 #[cfg(test)]
 mod reset_token_tests {
     use super::*;

--- a/api-rust/src/utils/jwt.rs
+++ b/api-rust/src/utils/jwt.rs
@@ -51,3 +51,61 @@ pub fn extract_token_from_header(auth_header: &str) -> Option<&str> {
         None
     }
 }
+
+/// Password-reset token (Node parity: purpose-scoped, 15 minutes).
+#[derive(Debug, Serialize, Deserialize)]
+pub struct ResetClaims {
+    pub user_id: String,
+    pub email: String,
+    pub purpose: String,
+    pub exp: i64,
+}
+
+pub fn create_reset_token(
+    user_id: &str,
+    email: &str,
+    secret: &str,
+) -> Result<String, jsonwebtoken::errors::Error> {
+    let claims = ResetClaims {
+        user_id: user_id.to_string(),
+        email: email.to_string(),
+        purpose: "reset_password".to_string(),
+        exp: (Utc::now() + Duration::minutes(15)).timestamp(),
+    };
+    encode(
+        &Header::default(),
+        &claims,
+        &EncodingKey::from_secret(secret.as_ref()),
+    )
+}
+
+pub fn verify_reset_token(token: &str, secret: &str) -> Result<ResetClaims, String> {
+    let mut validation = Validation::new(Algorithm::HS256);
+    validation.validate_exp = true;
+    validation.set_required_spec_claims(&["exp"]);
+    let claims = decode::<ResetClaims>(
+        token,
+        &DecodingKey::from_secret(secret.as_ref()),
+        &validation,
+    )
+    .map(|d| d.claims)
+    .map_err(|e| e.to_string())?;
+    if claims.purpose != "reset_password" {
+        return Err("Invalid token purpose".to_string());
+    }
+    Ok(claims)
+}
+
+#[cfg(test)]
+mod reset_token_tests {
+    use super::*;
+
+    #[test]
+    fn reset_token_roundtrip() {
+        let token = create_reset_token("u1", "a@b.c", "secret").unwrap();
+        let claims = verify_reset_token(&token, "secret").unwrap();
+        assert_eq!(claims.user_id, "u1");
+        assert_eq!(claims.email, "a@b.c");
+        assert!(verify_reset_token(&token, "other").is_err());
+    }
+}

--- a/api-rust/src/websocket.rs
+++ b/api-rust/src/websocket.rs
@@ -56,9 +56,27 @@ impl WebSocketServer {
                 )
             },
         );
+        // Realtime voice proxy: /realtime/proxy?token=<jwt>
+        let proxy_pool = self.db_pool.clone();
+        let proxy_config = self.config.clone();
+        let proxy = warp::path!("realtime" / "proxy")
+            .and(warp::query::<std::collections::HashMap<String, String>>())
+            .and(warp::ws())
+            .map(
+                move |params: std::collections::HashMap<String, String>, ws: warp::ws::Ws| {
+                    let db_pool = proxy_pool.clone();
+                    let config = proxy_config.clone();
+                    let token = params.get("token").cloned().unwrap_or_default();
+                    ws.on_upgrade(move |socket| async move {
+                        Self::handle_realtime_proxy(socket, token, db_pool, config).await;
+                    })
+                },
+            );
+
         let routes = warp::path("graphql")
             .and(warp::path("subscriptions"))
             .and(sub)
+            .or(proxy)
             .with(
                 warp::cors()
                     .allow_any_origin()
@@ -80,6 +98,59 @@ impl WebSocketServer {
         warp::serve(routes).run(addr).await;
 
         Ok(())
+    }
+
+    /// Authorize and run a realtime voice proxy connection.
+    async fn handle_realtime_proxy(
+        socket: warp::ws::WebSocket,
+        token: String,
+        db_pool: DbPool,
+        config: AppConfig,
+    ) {
+        use crate::models::{Chat, Model};
+        use crate::schema::{chats, models};
+        use crate::utils::jwt::verify_realtime_token;
+
+        let claims = match verify_realtime_token(&token, &config.jwt_secret) {
+            Ok(claims) => claims,
+            Err(e) => {
+                warn!("Realtime proxy: invalid token: {}", e);
+                return;
+            }
+        };
+        let Ok(mut conn) = db_pool.get() else {
+            return;
+        };
+        let user: User = match users::table
+            .filter(users::id.eq(&claims.user_id))
+            .first(&mut conn)
+        {
+            Ok(user) => user,
+            Err(_) => return,
+        };
+        let chat: Chat = match chats::table
+            .filter(chats::id.eq(&claims.chat_id))
+            .filter(chats::user_id.eq(&user.id))
+            .first(&mut conn)
+        {
+            Ok(chat) => chat,
+            Err(_) => return,
+        };
+        let Some(model_id) = chat.model_id.clone().or(user.default_model_id.clone()) else {
+            return;
+        };
+        let model: Model = match models::table
+            .filter(models::model_id.eq(&model_id))
+            .filter(models::user_id.eq(&user.id))
+            .first(&mut conn)
+        {
+            Ok(model) => model,
+            Err(_) => return,
+        };
+        drop(conn);
+
+        let effective_config = config.with_user_settings(user.settings.as_ref());
+        crate::services::realtime::run_proxy(socket, effective_config, chat, model).await;
     }
 
     async fn handle_connection_init(


### PR DESCRIPTION
## Summary
This PR ports three major feature sets from the Node API to api-rust: password reset flow with email support, realtime voice session management, and message editing/regeneration with linked alternate replies.

## Key Changes

### Password Reset & Email Support
- Added `forgot_password` and `reset_password` mutations with reCAPTCHA verification
- Implemented SMTP mailer service for password-reset emails (15-minute token expiry)
- Added JWT utilities for purpose-scoped reset tokens (`ResetClaims`)
- Silent success for unknown/OAuth-only users to prevent email enumeration (Node parity)
- New config options: `smtp_host`, `smtp_port`, `smtp_secure`, `smtp_user`, `smtp_password`, `smtp_from`, `jwt_reset_password_secret`, `recaptcha_secret_key`

### Realtime Voice Sessions
- Added realtime voice proxy service (`/realtime/proxy` WebSocket endpoint)
- Support for OpenAI ephemeral WebRTC sessions and Yandex Speech Realtime fallback
- Voice selection with provider-specific defaults (OpenAI: shimmer, Yandex: marina)
- JWT-based authorization for proxy connections (`RealtimeClaims`)
- Upstream target resolution with proper authentication headers

### Message Regeneration & Linked Replies
- Implemented `edit_message` mutation with Node parity semantics:
  - Editing assistant messages resets to the prior user message
  - Deletes following messages, reuses first assistant reply as regeneration target
  - RAG-aware (preserves document context from prior messages)
- Added `linked_to_message_id` column support for alternate replies (`callOther`)
- Messages query now loads linked messages as `linkedMessages` field
- New `AddChatMessageInput` model for direct message insertion

### OpenAI Responses API Protocol
- New `openai_responses.rs` service for models supporting `/responses` endpoint (gpt-5, gpt-4.1, gpt-4o, o-series)
- Tool calling via `previous_response_id` + `function_call_output` items
- Reasoning model support (gpt-5 with minimal effort, o1/o3 without sampling params)
- Automatic protocol selection based on model ID prefix matching

### Refactoring & Utilities
- Extracted `stream_reply` and `regenerate_reply` helpers to reduce duplication in chat mutations
- Added `prepare_regeneration_target` for message reuse logic
- Message metadata parsing utility (`parsed_metadata()`) for accessing document IDs and tool calls
- Global search result types (`SearchChatResult`, `SearchMessageResult`, `SearchDocumentResult`)
- Client operation validation script for GraphQL schema compliance

### Database & Configuration
- Added SMTP and JWT reset secret configuration
- Message filtering now excludes linked alternate replies from main thread queries
- Proper transaction handling for message deletion cascades (chat_files cleanup)

## Notable Implementation Details
- Password reset tokens expire after 15 minutes (Node parity)
- SMTP disabled gracefully returns error response (not silent failure)
- Realtime proxy supports both OpenAI WebRTC and Yandex WebSocket upstreams
- Message editing preserves RAG document context from prior assistant messages
- Tool execution in Responses API uses `function_call_output` continuation pattern
- Reasoning models (o1/o3) automatically strip temperature/top_p sampling parameters

https://claude.ai/code/session_018GfDqRAeCbu2hgFja8Utu9