### PR TITLE
fix(bedrock): drop non-existent us-east-3 from model region lists

### DIFF
--- a/api/src/config/data/bedrock-models-config.json
+++ b/api/src/config/data/bedrock-models-config.json
@@ -344,7 +344,7 @@
     "provider": "amazon",
     "modelId": "amazon.titan-embed-text-v2:0",
     "name": "Titan Text Embeddings V2",
-    "regions": ["us-east-1", "us-east-2", "us-east-3", "eu-west-1", "eu-west-2", "eu-west-3"],
+    "regions": ["us-east-1", "us-east-2", "eu-west-1", "eu-west-2", "eu-west-3"],
     "maxInputTokens": 8192
   },
   {
@@ -357,48 +357,21 @@
     "provider": "amazon",
     "modelId": "amazon.titan-embed-text-v1",
     "name": "Titan Embeddings G1 - Text",
-    "regions": [
-      "us-east-1",
-      "us-east-2",
-      "us-east-3",
-      "eu-west-1",
-      "eu-west-2",
-      "eu-west-3",
-      "ca-central-1",
-      "eu-central-1"
-    ],
+    "regions": ["us-east-1", "us-east-2", "eu-west-1", "eu-west-2", "eu-west-3", "ca-central-1", "eu-central-1"],
     "maxInputTokens": 8192
   },
   {
     "provider": "amazon",
     "modelId": "amazon.titan-embed-text-v2:0",
     "name": "Titan Embeddings G2 - Text",
-    "regions": [
-      "us-east-1",
-      "us-east-2",
-      "us-east-3",
-      "eu-west-1",
-      "eu-west-2",
-      "eu-west-3",
-      "ca-central-1",
-      "eu-central-1"
-    ],
+    "regions": ["us-east-1", "us-east-2", "eu-west-1", "eu-west-2", "eu-west-3", "ca-central-1", "eu-central-1"],
     "maxInputTokens": 8192
   },
   {
     "provider": "amazon",
     "modelId": "amazon.titan-embed-image-v1",
     "name": "Titan Multimodal Embeddings G1",
-    "regions": [
-      "us-east-1",
-      "us-east-2",
-      "us-east-3",
-      "eu-west-1",
-      "eu-west-2",
-      "eu-west-3",
-      "ca-central-1",
-      "eu-central-1"
-    ]
+    "regions": ["us-east-1", "us-east-2", "eu-west-1", "eu-west-2", "eu-west-3", "ca-central-1", "eu-central-1"]
   },
   {
     "provider": "meta",
@@ -482,7 +455,7 @@
       "us": "us.mistral.pixtral-large-2502-v1:0"
     },
     "name": "Pixtral Large (25.02)",
-    "regions": ["us-east-1", "us-east-2", "us-east-3", "us-west-2", "eu-central-1", "eu-west-1", "eu-west-3"]
+    "regions": ["us-east-1", "us-east-2", "us-west-2", "eu-central-1", "eu-west-1", "eu-west-3"]
   },
 
   {


### PR DESCRIPTION
## Summary

`us-east-3` is not an AWS region, but it appeared in the `regions` arrays of five entries in `api/src/config/data/bedrock-models-config.json`:

- `amazon.titan-embed-text-v2:0` — Titan Text Embeddings V2
- `amazon.titan-embed-text-v1` — Titan Embeddings G1 - Text
- `amazon.titan-embed-text-v2:0` — Titan Embeddings G2 - Text
- `amazon.titan-embed-image-v1` — Titan Multimodal Embeddings G1
- `mistral.pixtral-large-2502-v1:0` — Pixtral Large (25.02)

## Why it was dead data

`BedrockApiProvider.getModels` builds a `modelId -> regions` map from this file and keeps a model only when the array contains the live Bedrock client region:

```ts
const regions = modelsRegions[model.modelId || ""];
if (!regions || !regions.includes(bedrockRegion)) {
  continue;
}
```

`bedrockRegion` comes from `this.bedrockClient.config.region()`, so it can only ever be a real AWS region. The `us-east-3` entries could never match anything and only made the region lists misleading to read.

## Changes

Removed the five `us-east-3` entries. No code changes — this is a data-only fix and behaviour is unchanged in every region.

Prettier reflowed three of the arrays onto a single line, since dropping the element brought them under the repo's 120-character print width. That accounts for the rest of the diff.

## Verification

- File still parses as valid JSON with all 51 entries intact
- `prettier --check` passes on the file (it also passed before the change, so formatting parity is preserved)
- No remaining `us-east-3` occurrences anywhere under `api/src`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018GfDqRAeCbu2hgFja8Utu9

---
_Generated by [Claude Code](https://claude.ai/code/session_018GfDqRAeCbu2hgFja8Utu9)_